### PR TITLE
Rename WithArgs to Args

### DIFF
--- a/src/DivertR/IActionRedirectBuilder.cs
+++ b/src/DivertR/IActionRedirectBuilder.cs
@@ -20,7 +20,7 @@ namespace DivertR
         
         new IActionRecordRedirect<TTarget> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
 
-        IActionRedirectBuilder<TTarget, TArgs> WithArgs<TArgs>()
+        IActionRedirectBuilder<TTarget, TArgs> Args<TArgs>()
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
     

--- a/src/DivertR/IActionViaBuilder.cs
+++ b/src/DivertR/IActionViaBuilder.cs
@@ -30,7 +30,7 @@ namespace DivertR
         IActionViaBuilder<TTarget, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
-        IActionViaBuilder<TTarget, TArgs> WithArgs<TArgs>()
+        IActionViaBuilder<TTarget, TArgs> Args<TArgs>()
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         new IActionCallStream<TTarget> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/IClassFuncViaBuilder.cs
+++ b/src/DivertR/IClassFuncViaBuilder.cs
@@ -37,7 +37,7 @@ namespace DivertR
         new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
-        new IClassFuncViaBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>()
+        new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Args<TArgs>()
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
 

--- a/src/DivertR/IFuncRedirectBuilder.cs
+++ b/src/DivertR/IFuncRedirectBuilder.cs
@@ -21,7 +21,7 @@ namespace DivertR
 
         new IFuncRecordRedirect<TTarget, TReturn> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
 
-        IFuncRedirectBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>()
+        IFuncRedirectBuilder<TTarget, TReturn, TArgs> Args<TArgs>()
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
 

--- a/src/DivertR/IFuncViaBuilder.cs
+++ b/src/DivertR/IFuncViaBuilder.cs
@@ -34,7 +34,7 @@ namespace DivertR
         IFuncViaBuilder<TTarget, TReturn, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
-        IFuncViaBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>()
+        IFuncViaBuilder<TTarget, TReturn, TArgs> Args<TArgs>()
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
         new IFuncCallStream<TTarget, TReturn> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/Internal/ActionRedirectBuilder.cs
+++ b/src/DivertR/Internal/ActionRedirectBuilder.cs
@@ -40,12 +40,12 @@ namespace DivertR.Internal
 
         public IRedirect Build<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Build(redirectDelegate, optionsAction);
+            return Args<TArgs>().Build(redirectDelegate, optionsAction);
         }
 
         public IRedirect Build<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Build(redirectDelegate, optionsAction);
+            return Args<TArgs>().Build(redirectDelegate, optionsAction);
         }
 
         public new IActionRecordRedirect<TTarget> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
@@ -56,7 +56,7 @@ namespace DivertR.Internal
             return new ActionRecordRedirect<TTarget>(recordRedirect.Redirect, callStream);
         }
 
-        public IActionRedirectBuilder<TTarget, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IActionRedirectBuilder<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return new ActionRedirectBuilder<TTarget, TArgs>(CallValidator, CallConstraint);
         }
@@ -92,7 +92,7 @@ namespace DivertR.Internal
         public new IActionRecordRedirect<TTarget, TArgs> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
         {
             var recordRedirect = base.Record(optionsAction);
-            var callStream = recordRedirect.CallStream.WithArgs<TArgs>();
+            var callStream = recordRedirect.CallStream.Args<TArgs>();
                 
             return new ActionRecordRedirect<TTarget, TArgs>(recordRedirect.Redirect, callStream);
         }

--- a/src/DivertR/Internal/ActionViaBuilder.cs
+++ b/src/DivertR/Internal/ActionViaBuilder.cs
@@ -54,22 +54,22 @@ namespace DivertR.Internal
 
         public IActionViaBuilder<TTarget, TArgs> Redirect<TArgs>(Delegate redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IActionViaBuilder<TTarget, TArgs> Redirect<TArgs>(Action redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IActionViaBuilder<TTarget, TArgs> Redirect<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IActionViaBuilder<TTarget, TArgs> Redirect<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IActionViaBuilder<TTarget> Retarget(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
@@ -81,12 +81,12 @@ namespace DivertR.Internal
 
         public IActionViaBuilder<TTarget, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Retarget(target, optionsAction);
+            return Args<TArgs>().Retarget(target, optionsAction);
         }
 
-        public IActionViaBuilder<TTarget, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IActionViaBuilder<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            var builder = _redirectBuilder.WithArgs<TArgs>();
+            var builder = _redirectBuilder.Args<TArgs>();
             
             return new ActionViaBuilder<TTarget, TArgs>(RedirectRepository, builder);
         }
@@ -101,7 +101,7 @@ namespace DivertR.Internal
 
         public IActionCallStream<TTarget, TArgs> Record<TArgs>(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Record(optionsAction);
+            return Args<TArgs>().Record(optionsAction);
         }
     }
 

--- a/src/DivertR/Internal/ClassFuncViaBuilder.cs
+++ b/src/DivertR/Internal/ClassFuncViaBuilder.cs
@@ -71,31 +71,31 @@ namespace DivertR.Internal
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Delegate redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(TReturn instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(instance, optionsAction);
+            return Args<TArgs>().Redirect(instance, optionsAction);
         }
 
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IClassFuncViaBuilder<TTarget, TReturn> Retarget(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
@@ -107,12 +107,12 @@ namespace DivertR.Internal
 
         public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Retarget(target, optionsAction);
+            return Args<TArgs>().Retarget(target, optionsAction);
         }
 
-        public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public new IClassFuncViaBuilder<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            var builder = _redirectBuilder.WithArgs<TArgs>();
+            var builder = _redirectBuilder.Args<TArgs>();
             return new ClassFuncViaBuilder<TTarget, TReturn, TArgs>(_via, builder);
         }
     }
@@ -176,7 +176,7 @@ namespace DivertR.Internal
 
         public new IFuncCallStream<TTarget, TReturn, TArgs> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
         {
-            return base.Record(optionsAction).WithArgs<TArgs>();
+            return base.Record(optionsAction).Args<TArgs>();
         }
     }
 }

--- a/src/DivertR/Internal/FuncRedirectBuilder.cs
+++ b/src/DivertR/Internal/FuncRedirectBuilder.cs
@@ -46,12 +46,12 @@ namespace DivertR.Internal
 
         public IRedirect Build<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Build(redirectDelegate, optionsAction);
+            return Args<TArgs>().Build(redirectDelegate, optionsAction);
         }
 
         public IRedirect Build<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Build(redirectDelegate, optionsAction);
+            return Args<TArgs>().Build(redirectDelegate, optionsAction);
         }
 
         public new IFuncRecordRedirect<TTarget, TReturn> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
@@ -63,7 +63,7 @@ namespace DivertR.Internal
             return new FuncRecordRedirect<TTarget, TReturn>(recordRedirect.Redirect, callStream);
         }
 
-        public IFuncRedirectBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IFuncRedirectBuilder<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return new FuncRedirectBuilder<TTarget, TReturn, TArgs>(CallValidator, CallConstraint);
         }
@@ -99,7 +99,7 @@ namespace DivertR.Internal
         public new IFuncRecordRedirect<TTarget, TReturn, TArgs> Record(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
         {
             var recordRedirect = base.Record(optionsAction);
-            var callStream = recordRedirect.CallStream.WithArgs<TArgs>();
+            var callStream = recordRedirect.CallStream.Args<TArgs>();
                 
             return new FuncRecordRedirect<TTarget, TReturn, TArgs>(recordRedirect.Redirect, callStream);
         }

--- a/src/DivertR/Internal/FuncViaBuilder.cs
+++ b/src/DivertR/Internal/FuncViaBuilder.cs
@@ -59,28 +59,28 @@ namespace DivertR.Internal
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Delegate redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(TReturn instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(instance, optionsAction);
+            return Args<TArgs>().Redirect(instance, optionsAction);
         }
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Redirect<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Redirect(redirectDelegate, optionsAction);
+            return Args<TArgs>().Redirect(redirectDelegate, optionsAction);
         }
 
         public new IFuncViaBuilder<TTarget, TReturn> Retarget(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null)
@@ -92,12 +92,12 @@ namespace DivertR.Internal
 
         public IFuncViaBuilder<TTarget, TReturn, TArgs> Retarget<TArgs>(TTarget target, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Retarget(target, optionsAction);
+            return Args<TArgs>().Retarget(target, optionsAction);
         }
 
-        public IFuncViaBuilder<TTarget, TReturn, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IFuncViaBuilder<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            var builder = _redirectBuilder.WithArgs<TArgs>();
+            var builder = _redirectBuilder.Args<TArgs>();
             
             return new FuncViaBuilder<TTarget, TReturn, TArgs>(RedirectRepository, builder);
         }
@@ -112,7 +112,7 @@ namespace DivertR.Internal
 
         public IFuncCallStream<TTarget, TReturn, TArgs> Record<TArgs>(Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Record(optionsAction);
+            return Args<TArgs>().Record(optionsAction);
         }
     }
 

--- a/src/DivertR/Record/IActionCallStream.cs
+++ b/src/DivertR/Record/IActionCallStream.cs
@@ -7,7 +7,7 @@ namespace DivertR.Record
     public interface IActionCallStream<TTarget> : ICallStream<IRecordedCall<TTarget>>
         where TTarget : class
     {
-        IActionCallStream<TTarget, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
+        IActionCallStream<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget>, CallArguments, TMap> mapper);
         
@@ -24,7 +24,7 @@ namespace DivertR.Record
     public interface IActionCallStream<TTarget, TArgs> : ICallStream<IRecordedCall<TTarget, TArgs>>
         where TTarget : class
     {
-        IActionCallStream<TTarget, TNewArgs> WithArgs<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
+        IActionCallStream<TTarget, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget, TArgs>, TArgs, TMap> mapper);
 

--- a/src/DivertR/Record/IFuncCallStream.cs
+++ b/src/DivertR/Record/IFuncCallStream.cs
@@ -7,7 +7,7 @@ namespace DivertR.Record
     public interface IFuncCallStream<TTarget, TReturn> : ICallStream<IFuncRecordedCall<TTarget, TReturn>>
         where TTarget : class
     {
-        IFuncCallStream<TTarget, TReturn, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
+        IFuncCallStream<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, TMap> mapper);
         
@@ -24,7 +24,7 @@ namespace DivertR.Record
     public interface IFuncCallStream<TTarget, TReturn, TArgs> : ICallStream<IFuncRecordedCall<TTarget, TReturn, TArgs>>
         where TTarget : class
     {
-        IFuncCallStream<TTarget, TReturn, TNewArgs> WithArgs<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
+        IFuncCallStream<TTarget, TReturn, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, TMap> mapper);
 

--- a/src/DivertR/Record/Internal/ActionCallStream.cs
+++ b/src/DivertR/Record/Internal/ActionCallStream.cs
@@ -17,9 +17,9 @@ namespace DivertR.Record.Internal
             _callValidator = callValidator;
         }
 
-        public IActionCallStream<TTarget, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IActionCallStream<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>(Calls, _callValidator);
+            return Args<TArgs>(Calls, _callValidator);
         }
 
         public ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget>, CallArguments, TMap> mapper)
@@ -39,30 +39,30 @@ namespace DivertR.Record.Internal
 
         public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify();
+            return Args<TArgs>().Verify();
         }
 
         public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>(Action<IRecordedCall<TTarget, TArgs>> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
         
-        internal static IActionCallStream<TTarget, TArgs> WithArgs<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        internal static IActionCallStream<TTarget, TArgs> Args<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             var valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
             callValidator.Validate(valueTupleMapper);
@@ -83,14 +83,14 @@ namespace DivertR.Record.Internal
             _callValidator = callValidator;
         }
 
-        public IActionCallStream<TTarget, TNewArgs> WithArgs<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IActionCallStream<TTarget, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             if (typeof(TNewArgs) == typeof(TArgs))
             {
                 return (IActionCallStream<TTarget, TNewArgs>) this;
             }
 
-            return ActionCallStream<TTarget>.WithArgs<TNewArgs>(Calls, _callValidator);
+            return ActionCallStream<TTarget>.Args<TNewArgs>(Calls, _callValidator);
         }
 
         public ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget, TArgs>, TArgs, TMap> mapper)
@@ -115,7 +115,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) base.Verify();
             }
             
-            return WithArgs<TNewArgs>().Verify();
+            return Args<TNewArgs>().Verify();
         }
 
         public IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>(Action<IRecordedCall<TTarget, TNewArgs>> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -125,7 +125,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) base.Verify(v);
             }
             
-            return WithArgs<TNewArgs>().Verify(visitor);
+            return Args<TNewArgs>().Verify(visitor);
         }
 
         public IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>(Action<IRecordedCall<TTarget, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -135,7 +135,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) VerifyInternal(v);
             }
             
-            return WithArgs<TNewArgs>().Verify(visitor);
+            return Args<TNewArgs>().Verify(visitor);
         }
 
         public async Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -145,7 +145,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) await base.Verify(v).ConfigureAwait(false);
             }
             
-            return await WithArgs<TNewArgs>().Verify(visitor).ConfigureAwait(false);
+            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
         }
 
         public async Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -155,7 +155,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) await VerifyInternal(v).ConfigureAwait(false);
             }
             
-            return await WithArgs<TNewArgs>().Verify(visitor).ConfigureAwait(false);
+            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
         }
         
         private IVerifySnapshot<IRecordedCall<TTarget, TArgs>> VerifyInternal(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor)

--- a/src/DivertR/Record/Internal/FuncCallStream.cs
+++ b/src/DivertR/Record/Internal/FuncCallStream.cs
@@ -17,9 +17,9 @@ namespace DivertR.Record.Internal
             _callValidator = callValidator;
         }
 
-        public IFuncCallStream<TTarget, TReturn, TArgs> WithArgs<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IFuncCallStream<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>(Calls, _callValidator);
+            return Args<TArgs>(Calls, _callValidator);
         }
         
         public ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, TMap> mapper)
@@ -39,30 +39,30 @@ namespace DivertR.Record.Internal
 
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify();
+            return Args<TArgs>().Verify();
         }
 
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
 
         public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return WithArgs<TArgs>().Verify(visitor);
+            return Args<TArgs>().Verify(visitor);
         }
         
-        internal static IFuncCallStream<TTarget, TReturn, TArgs> WithArgs<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        internal static IFuncCallStream<TTarget, TReturn, TArgs> Args<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             var valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
             callValidator.Validate(valueTupleMapper);
@@ -83,14 +83,14 @@ namespace DivertR.Record.Internal
             _callValidator = callValidator;
         }
 
-        public IFuncCallStream<TTarget, TReturn, TNewArgs> WithArgs<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        public IFuncCallStream<TTarget, TReturn, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             if (typeof(TNewArgs) == typeof(TArgs))
             {
                 return (IFuncCallStream<TTarget, TReturn, TNewArgs>) this;
             }
             
-            return FuncCallStream<TTarget, TReturn>.WithArgs<TNewArgs>(Calls, _callValidator);
+            return FuncCallStream<TTarget, TReturn>.Args<TNewArgs>(Calls, _callValidator);
         }
 
         public ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, TMap> mapper)
@@ -115,7 +115,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) base.Verify();
             }
 
-            return WithArgs<TNewArgs>().Verify();
+            return Args<TNewArgs>().Verify();
         }
 
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -125,7 +125,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) base.Verify(v);
             }
             
-            return WithArgs<TNewArgs>().Verify(visitor);
+            return Args<TNewArgs>().Verify(visitor);
         }
 
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -135,7 +135,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) VerifyInternal(v);
             }
             
-            return WithArgs<TNewArgs>().Verify(visitor);
+            return Args<TNewArgs>().Verify(visitor);
         }
 
         public async Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -145,7 +145,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) await base.Verify(v).ConfigureAwait(false);
             }
             
-            return await WithArgs<TNewArgs>().Verify(visitor).ConfigureAwait(false);
+            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
         }
 
         public async Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
@@ -155,7 +155,7 @@ namespace DivertR.Record.Internal
                 return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) await VerifyInternal(v).ConfigureAwait(false);
             }
             
-            return await WithArgs<TNewArgs>().Verify(visitor).ConfigureAwait(false);
+            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
         }
         
         private IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> VerifyInternal(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor)

--- a/test/DivertR.UnitTests/RecordRedirectTests.cs
+++ b/test/DivertR.UnitTests/RecordRedirectTests.cs
@@ -104,7 +104,7 @@ namespace DivertR.UnitTests
                 call.Returned?.Value.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(string input, __)>().Verify(call =>
+            calls.Args<(string input, __)>().Verify(call =>
             {
                 call.Args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBe(result);
@@ -157,13 +157,13 @@ namespace DivertR.UnitTests
                 call.Returned?.Value.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(string input, __)>().Verify(call =>
+            calls.Args<(string input, __)>().Verify(call =>
             {
                 call.Args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(object input, __)>().Verify(call =>
+            calls.Args<(object input, __)>().Verify(call =>
             {
                 call.Args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBe(result);
@@ -402,7 +402,7 @@ namespace DivertR.UnitTests
                 call.Returned?.Value.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(string input, __)>().Verify<(string input, __)>((call, args) =>
+            calls.Args<(string input, __)>().Verify<(string input, __)>((call, args) =>
             {
                 args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBeNull();
@@ -455,13 +455,13 @@ namespace DivertR.UnitTests
                 call.Returned?.Value.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(string input, __)>().Verify(call =>
+            calls.Args<(string input, __)>().Verify(call =>
             {
                 call.Args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.WithArgs<(object input, __)>().Verify(call =>
+            calls.Args<(object input, __)>().Verify(call =>
             {
                 call.Args.input.ShouldBe(input);
                 call.Returned?.Value.ShouldBeNull();
@@ -506,7 +506,7 @@ namespace DivertR.UnitTests
                 call.Returned?.Value.ShouldBe(_foo.Echo((string) args[0]));
             }).Count.ShouldBe(inputs.Length);
             
-            calls.WithArgs<(string input, __)>().Select((call, i) =>
+            calls.Args<(string input, __)>().Select((call, i) =>
             {
                 call.Args.input.ShouldBe(inputs[i]);
                 call.Returned?.Value.ShouldBe(_foo.Echo(call.Args.input));

--- a/test/DivertR.UnitTests/RecordStreamTests.cs
+++ b/test/DivertR.UnitTests/RecordStreamTests.cs
@@ -43,7 +43,7 @@ namespace DivertR.UnitTests
 
             var echoCalls = _recordStream
                 .To(x => x.Echo(Is<string>.Any))
-                .WithArgs<(string input, __)>();
+                .Args<(string input, __)>();
             
             echoCalls.Select(call => call.Args.input).ShouldBe(inputs);
             echoCalls.Select(call => call.Returned!.Value).ShouldBe(outputs);
@@ -73,7 +73,7 @@ namespace DivertR.UnitTests
             // ACT
             var calls = _recordStream
                 .To(x => x.Echo(inputs[0]))
-                .WithArgs<(string input, __)>();
+                .Args<(string input, __)>();
 
             // ASSERT
             calls.Count().ShouldBe(1);
@@ -226,7 +226,7 @@ namespace DivertR.UnitTests
             // ASSERT
             _recordStream
                 .To(x => x.SetName(Is<string>.Any))
-                .WithArgs<(string name, __)>()
+                .Args<(string name, __)>()
                 .Select((call, i) =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -284,7 +284,7 @@ namespace DivertR.UnitTests
             // ASSERT
             var recordedCalls = _recordStream
                 .ToSet(x => x.Name, () => Is<string>.Any)
-                .WithArgs<(string name, __)>();
+                .Args<(string name, __)>();
                 
             recordedCalls
                 .Select(call => call.Args.name)
@@ -349,7 +349,7 @@ namespace DivertR.UnitTests
 
             var mappedCalls = _recordStream
                 .To(x => x.Echo(Is<string>.Any))
-                .WithArgs<(string input, __)>()
+                .Args<(string input, __)>()
                 .Map((call, args) => new { Input = args.input, Result = call.Returned });
 
             var fooProxy = _via.Proxy();
@@ -380,7 +380,7 @@ namespace DivertR.UnitTests
 
             var mappedCalls = _recordStream
                 .To(x => x.EchoAsync(Is<string>.Any))
-                .WithArgs<(string input, __)>()
+                .Args<(string input, __)>()
                 .Map((call, args) => new { Input = args.input, Result = call.Returned });
 
             var fooProxy = _via.Proxy();

--- a/test/DivertR.UnitTests/ViaActionParamTests.cs
+++ b/test/DivertR.UnitTests/ViaActionParamTests.cs
@@ -135,7 +135,7 @@ namespace DivertR.UnitTests
             result.ShouldBe(_inputs[0][0].Result);
             _recordStream
                 .To(x => x.GenericAction(_inputs[0][0].Arg))
-                .WithArgs<(int i1, __)>()
+                .Args<(int i1, __)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -157,7 +157,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[1][0].Result, _inputs[1][1].Result));
             _recordStream
                 .To(x => x.GenericAction(_inputs[1][0].Arg, _inputs[1][1].Arg))
-                .WithArgs<(int i1, int i2)>()
+                .Args<(int i1, int i2)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -180,7 +180,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[2][0].Result, _inputs[2][1].Result, _inputs[2][2].Result));
             _recordStream
                 .To(x => x.GenericAction(_inputs[2][0].Arg, _inputs[2][1].Arg, _inputs[2][2].Arg))
-                .WithArgs<(int i1, int i2, int i3)>()
+                .Args<(int i1, int i2, int i3)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -204,7 +204,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[3][0].Result, _inputs[3][1].Result, _inputs[3][2].Result, _inputs[3][3].Result));
             _recordStream
                 .To(x => x.GenericAction(_inputs[3][0].Arg, _inputs[3][1].Arg, _inputs[3][2].Arg, _inputs[3][3].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4)>()
+                .Args<(int i1, int i2, int i3, int i4)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -232,7 +232,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.GenericAction(_inputs[4][0].Arg, _inputs[4][1].Arg, _inputs[4][2].Arg, _inputs[4][3].Arg,
                     _inputs[4][4].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -261,7 +261,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.GenericAction(_inputs[5][0].Arg, _inputs[5][1].Arg, _inputs[5][2].Arg, _inputs[5][3].Arg,
                     _inputs[5][4].Arg, _inputs[5][5].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -291,7 +291,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.GenericAction(_inputs[6][0].Arg, _inputs[6][1].Arg, _inputs[6][2].Arg, _inputs[6][3].Arg,
                     _inputs[6][4].Arg, _inputs[6][5].Arg, _inputs[6][6].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6, int i7)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6, int i7)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();
@@ -322,7 +322,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.GenericAction(_inputs[7][0].Arg, _inputs[7][1].Arg, _inputs[7][2].Arg, _inputs[7][3].Arg,
                     _inputs[7][4].Arg, _inputs[7][5].Arg, _inputs[7][6].Arg, _inputs[7][7].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBeNull();

--- a/test/DivertR.UnitTests/ViaFuncParamTests.cs
+++ b/test/DivertR.UnitTests/ViaFuncParamTests.cs
@@ -126,7 +126,7 @@ namespace DivertR.UnitTests
             result.ShouldBe(_inputs[0][0].Result);
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[0][0].Arg))
-                .WithArgs<(int i1, __)>()
+                .Args<(int i1, __)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -147,7 +147,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[1][0].Result, _inputs[1][1].Result));
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[1][0].Arg, _inputs[1][1].Arg))
-                .WithArgs<(int i1, int i2)>()
+                .Args<(int i1, int i2)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -169,7 +169,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[2][0].Result, _inputs[2][1].Result, _inputs[2][2].Result));
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[2][0].Arg, _inputs[2][1].Arg, _inputs[2][2].Arg))
-                .WithArgs<(int i1, int i2, int i3)>()
+                .Args<(int i1, int i2, int i3)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -192,7 +192,7 @@ namespace DivertR.UnitTests
             result.ShouldBe((_inputs[3][0].Result, _inputs[3][1].Result, _inputs[3][2].Result, _inputs[3][3].Result));
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[3][0].Arg, _inputs[3][1].Arg, _inputs[3][2].Arg, _inputs[3][3].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4)>()
+                .Args<(int i1, int i2, int i3, int i4)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -219,7 +219,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[4][0].Arg, _inputs[4][1].Arg, _inputs[4][2].Arg, _inputs[4][3].Arg,
                     _inputs[4][4].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -247,7 +247,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[5][0].Arg, _inputs[5][1].Arg, _inputs[5][2].Arg, _inputs[5][3].Arg,
                     _inputs[5][4].Arg, _inputs[5][5].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -276,7 +276,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[6][0].Arg, _inputs[6][1].Arg, _inputs[6][2].Arg, _inputs[6][3].Arg,
                     _inputs[6][4].Arg, _inputs[6][5].Arg, _inputs[6][6].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6, int i7)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6, int i7)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);
@@ -306,7 +306,7 @@ namespace DivertR.UnitTests
             _recordStream
                 .To(x => x.EchoGeneric(_inputs[7][0].Arg, _inputs[7][1].Arg, _inputs[7][2].Arg, _inputs[7][3].Arg,
                     _inputs[7][4].Arg, _inputs[7][5].Arg, _inputs[7][6].Arg, _inputs[7][7].Arg))
-                .WithArgs<(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8)>()
+                .Args<(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8)>()
                 .Verify(call =>
                 {
                     call.Returned!.Value.ShouldBe(result);


### PR DESCRIPTION
Rename all `WithArgs` method names to `Args`