### PR TITLE
Simplify redirect builder constraint data structure

### DIFF
--- a/src/DivertR/IRedirectOptionsBuilder.cs
+++ b/src/DivertR/IRedirectOptionsBuilder.cs
@@ -10,7 +10,7 @@ namespace DivertR
         IRedirectOptionsBuilder<TTarget> DisableSatisfyStrict(bool disableStrict = true);
         
         IRedirectOptionsBuilder<TTarget> DecorateCallHandler(Func<ICallHandler<TTarget>, ICallHandler<TTarget>> decorator);
-        IRedirectOptionsBuilder<TTarget> DecorateCallConstraint(Func<ICallConstraint<TTarget>, ICallConstraint<TTarget>> decorator);
+        IRedirectOptionsBuilder<TTarget> AddCallConstraint(ICallConstraint<TTarget> callConstraint);
         
         IRedirectOptionsBuilder<TTarget> Repeat(int repeatCount);
         IRedirectOptionsBuilder<TTarget> Skip(int skipCount);

--- a/src/DivertR/Internal/ActionRedirectBuilder.cs
+++ b/src/DivertR/Internal/ActionRedirectBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using DivertR.Record;
 using DivertR.Record.Internal;
 
@@ -9,6 +10,11 @@ namespace DivertR.Internal
     {
         public ActionRedirectBuilder(ICallValidator callValidator, ICallConstraint<TTarget> callConstraint)
             : base(callValidator, callConstraint)
+        {
+        }
+        
+        protected ActionRedirectBuilder(ICallValidator callValidator, ConcurrentBag<ICallConstraint<TTarget>> callConstraints)
+            : base(callValidator, callConstraints)
         {
         }
         
@@ -58,7 +64,7 @@ namespace DivertR.Internal
 
         public IActionRedirectBuilder<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return new ActionRedirectBuilder<TTarget, TArgs>(CallValidator, CallConstraint);
+            return new ActionRedirectBuilder<TTarget, TArgs>(CallValidator, CallConstraints);
         }
     }
 
@@ -68,8 +74,8 @@ namespace DivertR.Internal
     {
         private readonly IValueTupleMapper _valueTupleMapper;
         
-        public ActionRedirectBuilder(ICallValidator callValidator, ICallConstraint<TTarget> callConstraint)
-            : base(callValidator, callConstraint)
+        public ActionRedirectBuilder(ICallValidator callValidator, ConcurrentBag<ICallConstraint<TTarget>> callConstraints)
+            : base(callValidator, callConstraints)
         {
             _valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
             CallValidator.Validate(_valueTupleMapper);

--- a/src/DivertR/Internal/CompositeCallConstraint.cs
+++ b/src/DivertR/Internal/CompositeCallConstraint.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -7,25 +9,13 @@ namespace DivertR.Internal
 {
     internal class CompositeCallConstraint<TTarget> : ICallConstraint<TTarget> where TTarget : class
     {
-        private readonly ImmutableArray<ICallConstraint<TTarget>> _callConstraints;
+        private readonly ReadOnlyCollection<ICallConstraint<TTarget>> _callConstraints;
         
-        public static readonly CompositeCallConstraint<TTarget> Empty = new CompositeCallConstraint<TTarget>(ImmutableArray<ICallConstraint<TTarget>>.Empty);
-
-        private CompositeCallConstraint(ImmutableArray<ICallConstraint<TTarget>> callConstraints)
+        public CompositeCallConstraint(IEnumerable<ICallConstraint<TTarget>> callConstraints)
         {
-            _callConstraints = callConstraints;
+            _callConstraints = Array.AsReadOnly(callConstraints.ToArray());
         }
 
-        public CompositeCallConstraint<TTarget> AddCallConstraint(ICallConstraint<TTarget> callConstraint)
-        {
-            return new CompositeCallConstraint<TTarget>(_callConstraints.Add(callConstraint));
-        }
-        
-        public CompositeCallConstraint<TTarget> AddCallConstraints(IEnumerable<ICallConstraint<TTarget>> callConstraints)
-        {
-            return new CompositeCallConstraint<TTarget>(_callConstraints.AddRange(callConstraints));
-        }
-        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsMatch(ICallInfo<TTarget> callInfo)
         {
@@ -35,25 +25,13 @@ namespace DivertR.Internal
     
     internal class CompositeCallConstraint : ICallConstraint
     {
-        private readonly ImmutableArray<ICallConstraint> _callConstraints;
-        
-        public static readonly CompositeCallConstraint Empty = new CompositeCallConstraint(ImmutableArray<ICallConstraint>.Empty);
+        private readonly ReadOnlyCollection<ICallConstraint> _callConstraints;
 
-        private CompositeCallConstraint(ImmutableArray<ICallConstraint> callConstraints)
+        public CompositeCallConstraint(IEnumerable<ICallConstraint> callConstraints)
         {
-            _callConstraints = callConstraints;
+            _callConstraints = Array.AsReadOnly(callConstraints.ToArray());
         }
 
-        public CompositeCallConstraint AddCallConstraint(ICallConstraint callConstraint)
-        {
-            return new CompositeCallConstraint(_callConstraints.Add(callConstraint));
-        }
-        
-        public CompositeCallConstraint AddCallConstraints(IEnumerable<ICallConstraint> callConstraints)
-        {
-            return new CompositeCallConstraint(_callConstraints.AddRange(callConstraints));
-        }
-        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsMatch(ICallInfo callInfo)
         {

--- a/src/DivertR/Internal/FuncRedirectBuilder.cs
+++ b/src/DivertR/Internal/FuncRedirectBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Linq;
 using DivertR.Record;
 using DivertR.Record.Internal;
@@ -12,6 +13,11 @@ namespace DivertR.Internal
             : base(callValidator, callConstraint)
         {
         }
+        
+        protected FuncRedirectBuilder(ICallValidator callValidator, ConcurrentBag<ICallConstraint<TTarget>> callConstraints)
+            : base(callValidator, callConstraints)
+        {
+        } 
         
         public new IFuncRedirectBuilder<TTarget, TReturn> AddConstraint(ICallConstraint<TTarget> callConstraint)
         {
@@ -65,7 +71,7 @@ namespace DivertR.Internal
 
         public IFuncRedirectBuilder<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
-            return new FuncRedirectBuilder<TTarget, TReturn, TArgs>(CallValidator, CallConstraint);
+            return new FuncRedirectBuilder<TTarget, TReturn, TArgs>(CallValidator, CallConstraints);
         }
     }
 
@@ -75,8 +81,8 @@ namespace DivertR.Internal
     {
         private readonly IValueTupleMapper _valueTupleMapper;
         
-        public FuncRedirectBuilder(ICallValidator callValidator, ICallConstraint<TTarget> callConstraint)
-            : base(callValidator, callConstraint)
+        public FuncRedirectBuilder(ICallValidator callValidator, ConcurrentBag<ICallConstraint<TTarget>> callConstraints)
+            : base(callValidator, callConstraints)
         {
             _valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
             CallValidator.Validate(_valueTupleMapper);

--- a/src/DivertR/RedirectSwitch.cs
+++ b/src/DivertR/RedirectSwitch.cs
@@ -1,26 +1,34 @@
-﻿using System.Threading;
+﻿using System.Collections.Concurrent;
 
 namespace DivertR
 {
     public class RedirectSwitch : IRedirectSwitch
     {
-        private volatile int _isEnabled;
+        private readonly ConcurrentStack<bool> _switchState = new ConcurrentStack<bool>();
 
         public RedirectSwitch(bool isEnabled = true)
         {
-            _isEnabled = isEnabled ? 1 : 0;
+            _switchState.Push(isEnabled);
         }
 
-        public bool IsEnabled => _isEnabled == 1;
+        public bool IsEnabled
+        {
+            get
+            {
+                _switchState.TryPeek(out var result);
+
+                return result;
+            }
+        }
 
         public void Enable()
         {
-            Interlocked.Exchange(ref _isEnabled, 1);
+            _switchState.Push(true);
         }
 
         public void Disable()
         {
-            Interlocked.Exchange(ref _isEnabled, 0);
+            _switchState.Push(false);
         }
     }
 }


### PR DESCRIPTION
Simplify RedirectBuilder CallConstraints data structure using ConcurrentBag instead of ImmutableArray. 