### PR TITLE
Cache RedirectVia proxies

### DIFF
--- a/src/DivertR/DivertR.csproj
+++ b/src/DivertR/DivertR.csproj
@@ -28,6 +28,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.1" Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/DivertR/IFuncRedirectCall.cs
+++ b/src/DivertR/IFuncRedirectCall.cs
@@ -1,13 +1,21 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DivertR
 {
     public interface IFuncRedirectCall<out TReturn> : IRedirectCall
     {
+        [return: MaybeNull]
         new TReturn CallNext();
+        
+        [return: MaybeNull]
         new TReturn CallNext(CallArguments args);
+        
+        [return: MaybeNull]
         new TReturn CallRoot();
+        
+        [return: MaybeNull]
         new TReturn CallRoot(CallArguments args);
     }
     

--- a/src/DivertR/Internal/CompositeCallConstraint.cs
+++ b/src/DivertR/Internal/CompositeCallConstraint.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/src/DivertR/Internal/FuncRedirectCall.cs
+++ b/src/DivertR/Internal/FuncRedirectCall.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace DivertR.Internal
@@ -60,24 +61,28 @@ namespace DivertR.Internal
         {
         }
         
+        [return: MaybeNull]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public new TReturn CallNext()
         {
             return (TReturn) base.CallNext()!;
         }
         
+        [return: MaybeNull]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public new TReturn CallNext(CallArguments args)
         {
             return (TReturn) base.CallNext(args)!;
         }
         
+        [return: MaybeNull]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public new TReturn CallRoot()
         {
             return (TReturn) base.CallRoot()!;
         }
         
+        [return: MaybeNull]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public new TReturn CallRoot(CallArguments args)
         {

--- a/src/DivertR/Internal/RedirectRepository.cs
+++ b/src/DivertR/Internal/RedirectRepository.cs
@@ -12,12 +12,12 @@ namespace DivertR.Internal
 
         public RedirectRepository()
         {
-            _redirectPlans.Push(DivertR.Internal.RedirectPlan.Empty);
+            _redirectPlans.Push(Internal.RedirectPlan.Empty);
         }
         
         public RedirectRepository(IEnumerable<IRedirect> redirects)
         {
-            var redirectPlan = DivertR.Internal.RedirectPlan.Empty.InsertRedirects(redirects);
+            var redirectPlan = Internal.RedirectPlan.Empty.InsertRedirects(redirects);
             _redirectPlans.Push(redirectPlan);
         }
 
@@ -53,7 +53,7 @@ namespace DivertR.Internal
             lock (_lockObject)
             {
                 _redirectPlans.Clear();
-                _redirectPlans.Push(DivertR.Internal.RedirectPlan.Empty);
+                _redirectPlans.Push(Internal.RedirectPlan.Empty);
             }
         }
 

--- a/src/DivertR/Record/ICallReturn.cs
+++ b/src/DivertR/Record/ICallReturn.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DivertR.Record
 {
@@ -11,6 +12,7 @@ namespace DivertR.Record
     
     public interface ICallReturn<out TReturn> : ICallReturn
     {
+        [AllowNull]
         new TReturn Value { get; }
     }
 }

--- a/src/DivertR/Record/Internal/CallReturn.cs
+++ b/src/DivertR/Record/Internal/CallReturn.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -51,6 +52,7 @@ namespace DivertR.Record.Internal
             _callReturn = callReturn;
         }
         
+        [AllowNull]
         public TReturn Value
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/DivertR/ViaBuilderExtensions.cs
+++ b/src/DivertR/ViaBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace DivertR
 {
@@ -16,7 +18,7 @@ namespace DivertR
             where TTarget : class
             where TReturn : class
         {
-            var proxyCache = new ConcurrentDictionary<object, TReturn>();
+            var proxyCache = new ConcurrentDictionary<object, TReturn>(new ReferenceEqualityComparer<object>());
             var via = viaBuilder.Via.ViaSet.Via<TReturn>(name);
 
             TReturn? RedirectDelegate(IFuncRedirectCall<TTarget, TReturn> call)
@@ -35,6 +37,19 @@ namespace DivertR
             viaBuilder.Via.RedirectRepository.InsertRedirect(redirect);
 
             return via;
+        }
+        
+        private class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
+        {
+            public int GetHashCode(T value)
+            {
+                return RuntimeHelpers.GetHashCode(value);
+            }
+
+            public bool Equals(T left, T right)
+            {
+                return ReferenceEquals(left, right);
+            }
         }
     }
 }

--- a/src/DivertR/ViaBuilderExtensions.cs
+++ b/src/DivertR/ViaBuilderExtensions.cs
@@ -19,12 +19,19 @@ namespace DivertR
             var proxyCache = new ConcurrentDictionary<object, TReturn>();
             var via = viaBuilder.Via.ViaSet.Via<TReturn>(name);
 
-            TReturn RedirectDelegate(IFuncRedirectCall<TTarget, TReturn> call)
+            TReturn? RedirectDelegate(IFuncRedirectCall<TTarget, TReturn> call)
             {
-                return proxyCache.GetOrAdd(call.CallNext(), callReturn => via.Proxy(callReturn));
+                var callReturn = call.CallNext();
+
+                if (callReturn == null)
+                {
+                    return null;
+                }
+                
+                return proxyCache.GetOrAdd(callReturn, x => via.Proxy(x));
             }
 
-            var redirect = viaBuilder.RedirectBuilder.Build(RedirectDelegate, optionsAction);
+            var redirect = viaBuilder.RedirectBuilder.Build(RedirectDelegate!, optionsAction);
             viaBuilder.Via.RedirectRepository.InsertRedirect(redirect);
 
             return via;

--- a/test/DivertR.UnitTests/RedirectViaTests.cs
+++ b/test/DivertR.UnitTests/RedirectViaTests.cs
@@ -179,5 +179,21 @@ namespace DivertR.UnitTests
             numberProxy1.ShouldBeSameAs(numberProxy2);
             numberProxy3.ShouldNotBeSameAs(numberProxy1);
         }
+        
+        [Fact]
+        public void GivenRedirectVia_WhenReturnIsNull_ThenShouldReturnNull()
+        {
+            // ARRANGE
+            _via
+                .To(x => x.EchoGeneric(Is<INumber>.Any))
+                .Redirect(() => null)
+                .RedirectVia();
+
+            // ACT
+            var result = _proxy.EchoGeneric<INumber>(new Number());
+            
+            // ASSERT
+            result.ShouldBeNull();
+        }
     }
 }

--- a/test/DivertR.UnitTests/RedirectViaTests.cs
+++ b/test/DivertR.UnitTests/RedirectViaTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace DivertR.UnitTests
 {
-    public class ViaDivertTests
+    public class RedirectViaTests
     {
         private readonly IVia<IFoo> _via = new Via<IFoo>();
         private readonly IFoo _proxy;
 
-        public ViaDivertTests()
+        public RedirectViaTests()
         {
             _proxy = _via.Proxy(new Foo());
         }
@@ -128,6 +128,56 @@ namespace DivertR.UnitTests
             
             // ASSERT
             results.ShouldBe(input.Select(x => $"redirect: {x} diverted"));
+        }
+        
+        [Fact]
+        public void GivenRedirectViaWithMultipleProxies_ShouldRedirect()
+        {
+            // ARRANGE
+            var numberVia = _via
+                .To(x => x.EchoGeneric(Is<INumber>.Any))
+                .RedirectVia();
+
+            var counter = 0;
+
+            numberVia
+                .To(x => x.GetNumber(Is<int>.Any))
+                .Redirect(call =>
+                {
+                    counter += 10;
+                    return call.CallNext() + counter;
+                });
+            
+            var numberProxy1 = _proxy.EchoGeneric<INumber>(new Number());
+            var numberProxy2 = _proxy.EchoGeneric<INumber>(new Number());
+            
+            // ACT
+            var result1 = numberProxy1.GetNumber(1);
+            var result2 = numberProxy2.GetNumber(1);
+
+            // ASSERT
+            result1.ShouldBe(11);
+            result2.ShouldBe(21);
+        }
+        
+        [Fact]
+        public void GivenRedirectVia_WhenSameReturnInstance_ThenShouldCacheProxies()
+        {
+            // ARRANGE
+            _via
+                .To(x => x.EchoGeneric(Is<INumber>.Any))
+                .RedirectVia();
+
+            var number = new Number();
+            
+            // ACT
+            var numberProxy1 = _proxy.EchoGeneric<INumber>(number);
+            var numberProxy2 = _proxy.EchoGeneric<INumber>(number);
+            var numberProxy3 = _proxy.EchoGeneric<INumber>(new Number());
+            
+            // ASSERT
+            numberProxy1.ShouldBeSameAs(numberProxy2);
+            numberProxy3.ShouldNotBeSameAs(numberProxy1);
         }
     }
 }

--- a/test/DivertR.WebAppTests/WebAppTests.cs
+++ b/test/DivertR.WebAppTests/WebAppTests.cs
@@ -225,7 +225,7 @@ namespace DivertR.WebAppTests
             recordedCalls.Verify((call, args) =>
             {
                 args.foo.Name.ShouldBe(createFooRequest.Name);
-                call.Returned?.Exception.ShouldBeSameAs(testException);
+                call.Returned!.Exception.ShouldBeSameAs(testException);
             }).Count.ShouldBe(1);
         }
     }


### PR DESCRIPTION
Avoid the overhead of creating a proxy on every call by caching proxies based on the reference equality of the wrapped return instance.