### PR TITLE
Do not proxy null resolved dependencies

### DIFF
--- a/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,12 +58,12 @@ namespace DivertR.DependencyInjection
                     grp => grp.Select(x => x!.Action));
         }
 
-        private static Func<IServiceProvider, object> CreateViaProxyFactory(ServiceDescriptor descriptor, IVia via)
+        private static Func<IServiceProvider, object?> CreateViaProxyFactory(ServiceDescriptor descriptor, IVia via)
         {
-            object ProxyFactory(IServiceProvider provider)
+            object? ProxyFactory(IServiceProvider provider)
             {
                 var instance = GetServiceInstance(provider, descriptor);
-                return via.Proxy(instance);
+                return via.ViaSet.Settings.DependencyFactory.Create(via, instance);
             }
 
             return ProxyFactory;

--- a/src/DivertR/DiverterSettings.cs
+++ b/src/DivertR/DiverterSettings.cs
@@ -13,6 +13,8 @@ namespace DivertR
         
         public IProxyFactory ProxyFactory { get; }
 
+        public IDependencyFactory DependencyFactory { get; }
+        
         public bool DefaultWithDummyRoot { get; }
 
         public IDummyFactory DummyFactory { get; }
@@ -39,12 +41,15 @@ namespace DivertR
             }
         }
 
-        public DiverterSettings(IProxyFactory? proxyFactory = null,
+        public DiverterSettings(
+            IProxyFactory? proxyFactory = null,
+            IDependencyFactory? dependencyFactory = null,
             bool defaultWithDummyRoot = true,
             IDummyFactory? dummyFactory = null,
             ICallInvoker? callInvoker = null)
         {
             ProxyFactory = proxyFactory ?? new DispatchProxyFactory();
+            DependencyFactory = dependencyFactory ?? new DependencyFactory();
             DefaultWithDummyRoot = defaultWithDummyRoot;
             DummyFactory = dummyFactory ?? new DummyFactory();
             CallInvoker = callInvoker ?? DefaultCallInvoker;

--- a/src/DivertR/IDependencyFactory.cs
+++ b/src/DivertR/IDependencyFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace DivertR
+{
+    public interface IDependencyFactory
+    {
+        object? Create(IVia via, object? original);
+    }
+}

--- a/src/DivertR/Internal/DependencyFactory.cs
+++ b/src/DivertR/Internal/DependencyFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace DivertR.Internal
+{
+    internal class DependencyFactory : IDependencyFactory
+    {
+        public object? Create(IVia via, object? original)
+        {
+            if (original == null)
+            {
+                return null;
+            }
+
+            return via.Proxy(original);
+        }
+    }
+}

--- a/test/DivertR.UnitTests/ServiceCollectionTests.cs
+++ b/test/DivertR.UnitTests/ServiceCollectionTests.cs
@@ -98,5 +98,16 @@ namespace DivertR.UnitTests
             fooBefore.Name.ShouldBe("original");
             fooAfter.Name.ShouldBe("original");
         }
+        
+        [Fact]
+        public void ShouldNotProxyNullDependencies()
+        {
+            _services.AddSingleton<IFoo>(_ => null);
+            _services.Divert(_diverter);
+            var provider = _services.BuildServiceProvider();
+            var foo = provider.GetService<IFoo>();
+            
+            foo.ShouldBeNull();
+        }
     }
 }


### PR DESCRIPTION
- If the ServiceProvider original resolved instance is null then DivertR should not wrap this with a proxy and should pass through the null. This ensures the behaviour of the application will remain unchanged, e.g. for null checked logic.
- Add a `IDependencyFactory` interface to allow this behaviour to be customised via `DiverterSettings`