### PR TITLE
Include System.Threading.Tasks.Extensions for netstandard 2.0 only

### DIFF
--- a/src/DivertR.DynamicProxy/DivertR.DynamicProxy.csproj
+++ b/src/DivertR.DynamicProxy/DivertR.DynamicProxy.csproj
@@ -22,6 +22,7 @@
   <PropertyGroup>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DivertR/DispatchProxy/DispatchProxyFactory.cs
+++ b/src/DivertR/DispatchProxy/DispatchProxyFactory.cs
@@ -8,7 +8,7 @@
             
             IProxyInvoker CreateProxyInvoker(TTarget proxy)
             {
-                return new ProxyInvoker<TTarget>(proxyCall, proxy, root);
+                return new ProxyInvoker<TTarget>(proxyCall, proxy!, root);
             }
             
             return DiverterDispatchProxy.Create<TTarget>(CreateProxyInvoker);

--- a/src/DivertR/DivertR.csproj
+++ b/src/DivertR/DivertR.csproj
@@ -22,6 +22,7 @@
   <PropertyGroup>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DivertR.UnitTests/MapTests.cs
+++ b/test/DivertR.UnitTests/MapTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DivertR.Record;
 using DivertR.UnitTests.Model;
 using Shouldly;
 using Xunit;


### PR DESCRIPTION
An explicit nuget package reference for `System.Threading.Tasks.Extensions` is not required for netstandard 2.1