### PR TITLE
Allow ValueTuple discard type `__` in any position

### DIFF
--- a/src/DivertR/Internal/ExpressionCallValidator.cs
+++ b/src/DivertR/Internal/ExpressionCallValidator.cs
@@ -115,12 +115,19 @@ namespace DivertR.Internal
                     }
                 }
 
-                yield return (isValid, $"{(isValid ? "---" : "***")} [{index}:{parameterTypeName ?? "???"}] {message}");
+                var paramType = parameterTypeName ?? (argumentType.type == typeof(__) ? "__" : "???");
+
+                yield return (isValid, $"{(isValid ? "  =" : "  *")} [{index}:{paramType}] {message}");
             }
         }
 
         private static bool IsArgumentTypeValid((Type type, ParameterInfo? parameter) test, ParameterInfo? parameter, bool isStrict = true)
         {
+            if (test.type == typeof(__))
+            {
+                return true;
+            }
+            
             if (parameter == null)
             {
                 return false;

--- a/src/DivertR/Internal/ValueTupleMapper.cs
+++ b/src/DivertR/Internal/ValueTupleMapper.cs
@@ -34,7 +34,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return new ValueTuple<T1>((T1) args[0]);
+            return new ValueTuple<T1>(args.Map<T1>(0));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -50,32 +50,7 @@ namespace DivertR.Internal
         {
         }
     }
-    
-    internal class ValueTupleMapperDiscard<T1> : IValueTupleMapper
-    {
-        private static readonly Type[] ArgTypes = { typeof(T1) };
-        public Type[] ArgumentTypes => ArgTypes;
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public object ToTuple(Span<object> args)
-        {
-            return ((T1) args[0], __.Instance);
-        }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public object?[] ToObjectArray(object boxedTuple)
-        {
-            var valueTuple = (ValueTuple<T1, __>) boxedTuple;
 
-            return new object?[] { valueTuple.Item1 };
-        }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteBackReferences(Span<object> args, object boxedTuple)
-        {
-        }
-    }
-    
     internal class ValueTupleMapper<T1, T2> : IValueTupleMapper
     {
         private static readonly Type[] ArgTypes = { typeof(T1), typeof(T2) };
@@ -84,7 +59,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1]);
+            return (args.Map<T1>(0), args.Map<T2>(1));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -109,7 +84,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1], (T3) args[2]);
+            return (args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,7 +109,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3]);
+            return (args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2), args.Map<T4>(3));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -159,7 +134,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4]);
+            return (args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2), args.Map<T4>(3), args.Map<T5>(4));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -184,7 +159,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5]);
+            return (args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2), args.Map<T4>(3), args.Map<T5>(4), args.Map<T6>(5));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -209,7 +184,7 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            return ((T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6]);
+            return (args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2), args.Map<T4>(3), args.Map<T5>(4), args.Map<T6>(5), args.Map<T7>(6));
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -247,9 +222,10 @@ namespace DivertR.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object ToTuple(Span<object> args)
         {
-            var rest = (TRest) NestedMapper.ToTuple(args.Slice(7));
+            var argsRest = args.Length > 7 ? args.Slice(7) : Span<object>.Empty;
+            var rest = (TRest) NestedMapper.ToTuple(argsRest);
             return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(
-                (T1) args[0], (T2) args[1], (T3) args[2], (T4) args[3], (T5) args[4], (T6) args[5], (T7) args[6], rest);
+                args.Map<T1>(0), args.Map<T2>(1), args.Map<T3>(2), args.Map<T4>(3), args.Map<T5>(4), args.Map<T6>(5), args.Map<T7>(6), rest);
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -264,7 +240,22 @@ namespace DivertR.Internal
         public void WriteBackReferences(Span<object> args, object boxedTuple)
         {
             var valueTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>) boxedTuple;
-            NestedMapper.WriteBackReferences(args.Slice(7), valueTuple.Rest);
+            var argsRest = args.Length > 7 ? args.Slice(7) : Span<object>.Empty;
+            NestedMapper.WriteBackReferences(argsRest, valueTuple.Rest);
+        }
+    }
+    
+    internal static class MapTypeOrDiscardExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Map<T>(this Span<object> args, int index)
+        {
+            if (typeof(T) == typeof(__))
+            {
+                return (T) (object) __.Instance;
+            }
+
+            return (T) args[index];
         }
     }
 }

--- a/src/DivertR/__.cs
+++ b/src/DivertR/__.cs
@@ -2,7 +2,7 @@
 {
     public class __
     {
-        internal static readonly __ Instance = new __();
+        internal static readonly __ Instance = new();
         
         private __() { }
     }

--- a/test/DivertR.UnitTests/Model/INumber.cs
+++ b/test/DivertR.UnitTests/Model/INumber.cs
@@ -10,6 +10,7 @@ namespace DivertR.UnitTests.Model
         void RefArrayNumber(ref int[] inputs);
         int RefNumber(ref int input);
         void OutNumber(int input, out int output);
+        int RefOutNumber(ref int input, out int output);
         
         Task<int> GetNumberAsync(int input);
         ValueTask<int> GetNumberValueAsync(int input);

--- a/test/DivertR.UnitTests/Model/Number.cs
+++ b/test/DivertR.UnitTests/Model/Number.cs
@@ -47,6 +47,13 @@ namespace DivertR.UnitTests.Model
             output = _numberFactory(input);
         }
 
+        public int RefOutNumber(ref int input, out int output)
+        {
+            output = _numberFactory(input);
+            
+            return input;
+        }
+
         public void RefArrayNumber(ref int[] inputs)
         {
             var replacement = new int[inputs.Length];

--- a/test/DivertR.UnitTests/ValueTupleMapperTests.cs
+++ b/test/DivertR.UnitTests/ValueTupleMapperTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using DivertR.UnitTests.Model;
+using Shouldly;
+using Xunit;
+
+namespace DivertR.UnitTests
+{
+    public class ValueTupleMapperTests
+    {
+        private readonly IVia<IFoo> _via = new Via<IFoo>();
+        private readonly IFoo _proxy;
+
+        public ValueTupleMapperTests()
+        {
+            _proxy = _via.Proxy(new Foo("MrFoo"));
+        }
+
+        [Fact]
+        public void GivenRedirectValueTupleWithTypeAndDiscards_ShouldMap()
+        {
+            // ARRANGE
+            _via
+                .To(x => x.EchoGeneric(Is<int>.Any, Is<string>.Any, Is<bool>.Any))
+                .Redirect<(__, string input, __)>(call =>
+                {
+                    var args = call.CallInfo.Arguments.ToArray();
+                    args[1] = $"{call.Args.input} redirected";
+
+                    return call.CallNext(args);
+                });
+
+            // ACT
+            var result = _proxy.EchoGeneric(1, "hello", true);
+            
+            // ASSERT
+            result.ShouldBe((1, "hello redirected", true));
+        }
+        
+        [Fact]
+        public void GivenRedirectValueTupleWithLessTypeAndDiscards_ShouldMap()
+        {
+            // ARRANGE
+            _via
+                .To(x => x.EchoGeneric(Is<int>.Any, Is<string>.Any, Is<bool>.Any))
+                .Redirect<(__, string input)>(call =>
+                {
+                    var args = call.CallInfo.Arguments.ToArray();
+                    args[1] = $"{args[1]} redirected";
+
+                    return call.CallNext(args);
+                });
+
+            // ACT
+            var result = _proxy.EchoGeneric(1, "hello", true);
+            
+            // ASSERT
+            result.ShouldBe((1, "hello redirected", true));
+        }
+        
+        [Fact]
+        public void GivenRedirectValueTupleWithMoreTypeAndDiscards_ShouldMap()
+        {
+            // ARRANGE
+            _via
+                .To(x => x.EchoGeneric(Is<int>.Any, Is<string>.Any, Is<bool>.Any))
+                .Redirect<(__, string input, bool input2, __)>(call =>
+                {
+                    var args = call.CallInfo.Arguments.ToArray();
+                    args[1] = $"{args[1]} redirected";
+
+                    return call.CallNext(args);
+                });
+
+            // ACT
+            var result = _proxy.EchoGeneric(1, "hello", true);
+            
+            // ASSERT
+            result.ShouldBe((1, "hello redirected", true));
+        }
+        
+        [Fact]
+        public void GivenRedirectValueTupleWithOnlyDiscards_ShouldIgnore()
+        {
+            // ARRANGE
+
+            TReturn Callback<TTarget, TReturn, TArgs>(IFuncRedirectCall<TTarget, TReturn, TArgs> call)
+                where TTarget : class?
+                where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+            {
+                var args = call.CallInfo.Arguments.ToArray();
+                args[1] = $"{args[1]} {((ITuple) call.Args).Length}";
+
+                return call.CallNext(args);
+            }
+
+            _via
+                .To(x => x.EchoGeneric(Is<int>.Any, Is<string>.Any, Is<bool>.Any))
+                .Redirect<ValueTuple>(Callback)
+                .Redirect<ValueTuple<__>>(Callback)
+                .Redirect<(__, __)>(Callback)
+                .Redirect<(__, __, __)>(Callback)
+                .Redirect<(__, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __, __, __, __, __)>(Callback)
+                .Redirect<(__, __, __, __, __, __, __, __, __, __)>(Callback);
+
+            // ACT
+            var result = _proxy.EchoGeneric(1, "hello", true);
+            
+            // ASSERT
+            result.ShouldBe((1, "hello 10 9 8 7 6 5 4 3 2 1 0", true));
+        }
+    }
+}

--- a/test/DivertR.UnitTests/ValueTupleValidationTests.cs
+++ b/test/DivertR.UnitTests/ValueTupleValidationTests.cs
@@ -30,6 +30,19 @@ namespace DivertR.UnitTests
         }
         
         [Fact]
+        public void GivenInvalidRefArgumentType_ShouldThrowException()
+        {
+            // ARRANGE
+            var builder = _via.To(x => x.Echo(Is<string>.Any));
+
+            // ACT
+            Action testAction = () => builder.Redirect<(Ref<int> input, __)>(call => call.Args.input.Value.ToString());
+
+            // ASSERT
+            _output.WriteLine($"{testAction.ShouldThrow<DiverterValidationException>()}");
+        }
+        
+        [Fact]
         public void GivenTooManyArgumentTypes_ShouldThrowException()
         {
             // ARRANGE
@@ -64,7 +77,7 @@ namespace DivertR.UnitTests
             var builder = new Via<INumber>().To(x => x.OutNumber(Is<int>.Any, out IsRef<int>.Any));
 
             // ACT
-            Action testAction = () => builder.Redirect<(int input, int output)>(_ => { });
+            Action testAction = () => builder.Redirect<(int input, int output, __)>(_ => { });
 
             // ASSERT
             _output.WriteLine($"{testAction.ShouldThrow<DiverterValidationException>()}");


### PR DESCRIPTION
Allow defining the DivertR discard type `__` in any position when declaring redirect ValueTuple parameter mapping type.