### PR TITLE
Rename `AddContraint` methods to `Filter`

### DIFF
--- a/src/DivertR/Dummy/IDummyBuilder.cs
+++ b/src/DivertR/Dummy/IDummyBuilder.cs
@@ -5,7 +5,7 @@ namespace DivertR.Dummy
 {
     public interface IDummyBuilder<TReturn>
     {
-        IDummyBuilder<TReturn> AddConstraint(ICallConstraint callConstraint);
+        IDummyBuilder<TReturn> Filter(ICallConstraint callConstraint);
         IDummyBuilder<TReturn> Redirect(TReturn instance, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IDummyBuilder<TReturn> Redirect(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IDummyBuilder<TReturn> Redirect(Func<IFuncRedirectCall<TReturn>, TReturn> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);
@@ -15,7 +15,7 @@ namespace DivertR.Dummy
     
     public interface IDummyBuilder
     {
-        IDummyBuilder AddConstraint(ICallConstraint callConstraint);
+        IDummyBuilder Filter(ICallConstraint callConstraint);
         IDummyBuilder Redirect(object instance, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IDummyBuilder Redirect(Func<object> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IDummyBuilder Redirect(Func<IRedirectCall, object> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);

--- a/src/DivertR/Dummy/Internal/DummyBuilder.cs
+++ b/src/DivertR/Dummy/Internal/DummyBuilder.cs
@@ -14,9 +14,9 @@ namespace DivertR.Dummy.Internal
             _redirectBuilder = redirectBuilder;
         }
         
-        public IDummyBuilder<TReturn> AddConstraint(ICallConstraint callConstraint)
+        public IDummyBuilder<TReturn> Filter(ICallConstraint callConstraint)
         {
-            _redirectBuilder.AddConstraint(callConstraint);
+            _redirectBuilder.Filter(callConstraint);
 
             return this;
         }
@@ -73,9 +73,9 @@ namespace DivertR.Dummy.Internal
             _redirectBuilder = redirectBuilder;
         }
         
-        public IDummyBuilder AddConstraint(ICallConstraint callConstraint)
+        public IDummyBuilder Filter(ICallConstraint callConstraint)
         {
-            _redirectBuilder.AddConstraint(callConstraint);
+            _redirectBuilder.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/IActionRedirectBuilder.cs
+++ b/src/DivertR/IActionRedirectBuilder.cs
@@ -6,7 +6,7 @@ namespace DivertR
 {
     public interface IActionRedirectBuilder<TTarget> : IRedirectBuilder<TTarget> where TTarget : class?
     {
-        new IActionRedirectBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        new IActionRedirectBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint);
 
         IRedirect Build(Action redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IRedirect Build(Action<IActionRedirectCall<TTarget>> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/IActionViaBuilder.cs
+++ b/src/DivertR/IActionViaBuilder.cs
@@ -8,7 +8,7 @@ namespace DivertR
     {
         IVia<TTarget> Via { get; }
         IActionRedirectBuilder<TTarget> RedirectBuilder { get; }
-        IActionViaBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        IActionViaBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint);
         
         IActionViaBuilder<TTarget> Redirect(Action redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IActionViaBuilder<TTarget> Redirect(Action<IActionRedirectCall<TTarget>> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/IFuncRedirectBuilder.cs
+++ b/src/DivertR/IFuncRedirectBuilder.cs
@@ -6,7 +6,7 @@ namespace DivertR
 {
     public interface IFuncRedirectBuilder<TTarget, TReturn> : IRedirectBuilder<TTarget> where TTarget : class?
     {
-        new IFuncRedirectBuilder<TTarget, TReturn> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        new IFuncRedirectBuilder<TTarget, TReturn> Filter(ICallConstraint<TTarget> callConstraint);
 
         IRedirect Build(TReturn instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IRedirect Build(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
@@ -36,7 +36,7 @@ namespace DivertR
 
     public interface IFuncRedirectBuilder<TReturn> : IRedirectBuilder
     {
-        new IFuncRedirectBuilder<TReturn> AddConstraint(ICallConstraint callConstraint);
+        new IFuncRedirectBuilder<TReturn> Filter(ICallConstraint callConstraint);
         
         IRedirect Build(TReturn instance, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IRedirect Build(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);

--- a/src/DivertR/IFuncViaBuilder.cs
+++ b/src/DivertR/IFuncViaBuilder.cs
@@ -8,7 +8,7 @@ namespace DivertR
     {
         IVia<TTarget> Via { get; }
         IFuncRedirectBuilder<TTarget, TReturn> RedirectBuilder { get; }
-        IFuncViaBuilder<TTarget, TReturn> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        IFuncViaBuilder<TTarget, TReturn> Filter(ICallConstraint<TTarget> callConstraint);
         
         IFuncViaBuilder<TTarget, TReturn> Redirect(TReturn instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IFuncViaBuilder<TTarget, TReturn> Redirect(Func<TReturn> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/IRedirectBuilder.cs
+++ b/src/DivertR/IRedirectBuilder.cs
@@ -5,7 +5,7 @@ namespace DivertR
 {
     public interface IRedirectBuilder<TTarget> where TTarget : class?
     {
-        IRedirectBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        IRedirectBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint);
         IRedirect Build(object? instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IRedirect Build(Func<object?> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IRedirect Build(Func<IRedirectCall<TTarget>, object?> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
@@ -17,7 +17,7 @@ namespace DivertR
     
     public interface IRedirectBuilder
     {
-        IRedirectBuilder AddConstraint(ICallConstraint callConstraint);
+        IRedirectBuilder Filter(ICallConstraint callConstraint);
         IRedirect Build(object? instance, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IRedirect Build(Func<object?> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);
         IRedirect Build(Func<IRedirectCall, object?> redirectDelegate, Action<IRedirectOptionsBuilder>? optionsAction = null);

--- a/src/DivertR/IViaBuilder.cs
+++ b/src/DivertR/IViaBuilder.cs
@@ -8,7 +8,7 @@ namespace DivertR
         IVia<TTarget> Via { get; }
         IRedirectBuilder<TTarget> RedirectBuilder { get; }
         
-        IViaBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint);
+        IViaBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint);
         IViaBuilder<TTarget> Redirect(object? instance, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IViaBuilder<TTarget> Redirect(Func<object?> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);
         IViaBuilder<TTarget> Redirect(Func<IRedirectCall<TTarget>, object?> redirectDelegate, Action<IRedirectOptionsBuilder<TTarget>>? optionsAction = null);

--- a/src/DivertR/Internal/ActionRedirectBuilder.cs
+++ b/src/DivertR/Internal/ActionRedirectBuilder.cs
@@ -22,9 +22,9 @@ namespace DivertR.Internal
             CallValidator = callValidator;
         }
         
-        public new IActionRedirectBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public new IActionRedirectBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint)
         {
-            base.AddConstraint(callConstraint);
+            base.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/Internal/ActionViaBuilder.cs
+++ b/src/DivertR/Internal/ActionViaBuilder.cs
@@ -14,9 +14,9 @@ namespace DivertR.Internal
 
         public new IActionRedirectBuilder<TTarget> RedirectBuilder { get; }
 
-        public new IActionViaBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public new IActionViaBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint)
         {
-            base.AddConstraint(callConstraint);
+            base.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/Internal/FuncRedirectBuilder.cs
+++ b/src/DivertR/Internal/FuncRedirectBuilder.cs
@@ -23,9 +23,9 @@ namespace DivertR.Internal
             CallValidator = callValidator;
         } 
         
-        public new IFuncRedirectBuilder<TTarget, TReturn> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public new IFuncRedirectBuilder<TTarget, TReturn> Filter(ICallConstraint<TTarget> callConstraint)
         {
-            base.AddConstraint(callConstraint);
+            base.Filter(callConstraint);
 
             return this;
         }
@@ -121,9 +121,9 @@ namespace DivertR.Internal
         {
         }
 
-        public new IFuncRedirectBuilder<TReturn> AddConstraint(ICallConstraint callConstraint)
+        public new IFuncRedirectBuilder<TReturn> Filter(ICallConstraint callConstraint)
         {
-            base.AddConstraint(callConstraint);
+            base.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/Internal/FuncViaBuilder.cs
+++ b/src/DivertR/Internal/FuncViaBuilder.cs
@@ -14,9 +14,9 @@ namespace DivertR.Internal
 
         public new IFuncRedirectBuilder<TTarget, TReturn> RedirectBuilder { get; }
 
-        public new IFuncViaBuilder<TTarget, TReturn> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public new IFuncViaBuilder<TTarget, TReturn> Filter(ICallConstraint<TTarget> callConstraint)
         {
-            base.AddConstraint(callConstraint);
+            base.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/Internal/RedirectBuilder.cs
+++ b/src/DivertR/Internal/RedirectBuilder.cs
@@ -24,7 +24,7 @@ namespace DivertR.Internal
             CallConstraints = callConstraints;
         }
 
-        public IRedirectBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public IRedirectBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint)
         {
             CallConstraints.Add(callConstraint);
 
@@ -97,7 +97,7 @@ namespace DivertR.Internal
             _callConstraints = callConstraints;
         }
 
-        public IRedirectBuilder AddConstraint(ICallConstraint callConstraint)
+        public IRedirectBuilder Filter(ICallConstraint callConstraint)
         {
             _callConstraints.Add(callConstraint);
 

--- a/src/DivertR/Internal/ViaBuilder.cs
+++ b/src/DivertR/Internal/ViaBuilder.cs
@@ -14,9 +14,9 @@ namespace DivertR.Internal
         public IVia<TTarget> Via { get; }
         public IRedirectBuilder<TTarget> RedirectBuilder { get; }
 
-        public IViaBuilder<TTarget> AddConstraint(ICallConstraint<TTarget> callConstraint)
+        public IViaBuilder<TTarget> Filter(ICallConstraint<TTarget> callConstraint)
         {
-            RedirectBuilder.AddConstraint(callConstraint);
+            RedirectBuilder.Filter(callConstraint);
 
             return this;
         }

--- a/src/DivertR/Record/ICallStream.cs
+++ b/src/DivertR/Record/ICallStream.cs
@@ -6,7 +6,7 @@ namespace DivertR.Record
 {
     public interface ICallStream<T> : IReadOnlyCollection<T>
     {
-        ICallStream<T> Where(Func<T, bool> predicate);
+        ICallStream<T> Filter(Func<T, bool> predicate);
         ICallStream<TMap> Map<TMap>(Func<T, TMap> mapper);
         IVerifySnapshot<T> Verify();
         IVerifySnapshot<T> Verify(Action<T> visitor);

--- a/src/DivertR/Record/Internal/CallStream.cs
+++ b/src/DivertR/Record/Internal/CallStream.cs
@@ -15,7 +15,7 @@ namespace DivertR.Record.Internal
             Calls = calls ?? throw new ArgumentNullException(nameof(calls));
         }
 
-        public ICallStream<T> Where(Func<T, bool> predicate)
+        public ICallStream<T> Filter(Func<T, bool> predicate)
         {
             return new CallStream<T>(Calls.Where(predicate));
         }

--- a/test/DivertR.UnitTests/RecordRedirectTests.cs
+++ b/test/DivertR.UnitTests/RecordRedirectTests.cs
@@ -833,7 +833,7 @@ namespace DivertR.UnitTests
 
             // ASSERT
             calls
-                .Where(call => call.Args.input == results[5])
+                .Filter(call => call.Args.input == results[5])
                 .Verify(call => call.Args.input.ShouldBe(results[5])).Count.ShouldBe(1);
         }
     }

--- a/test/DivertR.UnitTests/ViaRedirectTests.cs
+++ b/test/DivertR.UnitTests/ViaRedirectTests.cs
@@ -475,7 +475,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             _via
                 .To(x => x.EchoGeneric(Is<object>.Any))
-                .AddConstraint(new MatchCallConstraint<IFoo>(callInfo => callInfo.Method.GetGenericArguments()[0] == typeof(object)))
+                .Filter(new MatchCallConstraint<IFoo>(callInfo => callInfo.Method.GetGenericArguments()[0] == typeof(object)))
                 .Redirect<(object i, __)>(call => $"{call.Args.i} - {_via.Relay.Next.Name}");
 
             // ACT
@@ -903,7 +903,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             _via
                 .To(x => x.Echo(Is<string>.Any))
-                .AddConstraint(new CallConstraint<IFoo>(call => (string) call.Arguments[0] != "ignore"))
+                .Filter(new CallConstraint<IFoo>(call => (string) call.Arguments[0] != "ignore"))
                 .Redirect<(string input, __)>(call => call.CallNext(new[] { $"{call.Args.input} redirected" }));
 
             var proxy = _via.Proxy(new Foo());


### PR DESCRIPTION
- Rename `AddConstraint` methods in builders to `Filter`.
- Also rename `Where` method in `ICallStream` to `Filter` for naming consistency and to avoid confusing with Linq `Where`.