### PR TITLE
Fix to correctly dispose DI resolved root instances

### DIFF
--- a/src/DivertR/DependencyInjection/TypePointer.cs
+++ b/src/DivertR/DependencyInjection/TypePointer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace DivertR.DependencyInjection
+{
+    public class TypePointer : TypeDelegator
+    {
+        public TypePointer(Type delegatingType) : base(delegatingType)
+        {
+        }
+        
+        public override bool Equals(Type? other) => ReferenceEquals(this, other);
+
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+    }
+}


### PR DESCRIPTION
This fixes and issue where Via decorated DI service registrations that are resolved to create proxy roots were not being disposed correctly when going out of DI scope.