### PR TITLE
Exclude DI container dispose of disposable proxy target roots

### DIFF
--- a/src/DivertR/DivertR.csproj
+++ b/src/DivertR/DivertR.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />

--- a/test/DivertR.UnitTests/DivertR.UnitTests.csproj
+++ b/test/DivertR.UnitTests/DivertR.UnitTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />


### PR DESCRIPTION
The previous PR #28 makes the DI container manage disposing created root instances. However, if the Via proxy target is an `IDisposable` or `IAsyncDisposable` then the DI container will already call `Dispose` on the generated proxies. As proxies forward calls to their roots by default the result is duplicate `Dispose` calls on the root. This PR fixes this by excluding the DI container dispose of disposable proxy target roots.