### PR TITLE
Add null default to ToSet constraint parameter that matches any value

### DIFF
--- a/src/DivertR/IVia.cs
+++ b/src/DivertR/IVia.cs
@@ -141,9 +141,9 @@ namespace DivertR
         /// Creates a Redirect builder from an Expression with a call constraint that matches a property setter member of <typeparamref name="TTarget"/> />.
         /// </summary>
         /// <param name="memberExpression">The expression for matching the property setter member.</param>
-        /// <param name="constraintExpression">The call constraint expression for the input value of the setter.</param>
+        /// <param name="constraintExpression">Optional constraint expression on the setter input argument. If null, the constraint defaults to match any value</param>
         /// <typeparam name="TProperty">The member type of the property setter.</typeparam>
         /// <returns>The Redirect builder instance.</returns>
-        IActionViaBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty?>> constraintExpression);
+        IActionViaBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty>>? constraintExpression = null);
     }
 }

--- a/src/DivertR/Internal/CallExpressionParser.cs
+++ b/src/DivertR/Internal/CallExpressionParser.cs
@@ -19,12 +19,11 @@ namespace DivertR.Internal
             };
         }
         
-        public static ICallValidator FromPropertySetter(MemberExpression propertyExpression, Expression valueExpression)
+        public static ICallValidator FromPropertySetter(MemberExpression propertyExpression, Expression? valueExpression)
         {
             if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
-            if (valueExpression == null) throw new ArgumentNullException(nameof(valueExpression));
-            
-            if (!(propertyExpression.Member is PropertyInfo property))
+
+            if (propertyExpression.Member is not PropertyInfo property)
             {
                 throw new ArgumentException($"Member expression must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
             }
@@ -32,7 +31,9 @@ namespace DivertR.Internal
             var methodInfo = property.GetSetMethod(true);
             var parameterInfos = methodInfo.GetParameters();
             var methodConstraint = CreateMethodConstraint(methodInfo);
-            var argumentConstraints = CreateArgumentConstraints(parameterInfos, new[] { valueExpression });
+            var argumentConstraints = valueExpression == null 
+                ? new[] { TrueArgumentConstraint.Instance }
+                : CreateArgumentConstraints(parameterInfos, new[] { valueExpression });
 
             return new ExpressionCallValidator(methodInfo, parameterInfos, methodConstraint, argumentConstraints);
         }
@@ -51,7 +52,7 @@ namespace DivertR.Internal
         {
             if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
             
-            if (!(propertyExpression.Member is PropertyInfo property))
+            if (propertyExpression.Member is not PropertyInfo property)
             {
                 throw new ArgumentException($"Member expression must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
             }

--- a/src/DivertR/Internal/MethodCallConstraint.cs
+++ b/src/DivertR/Internal/MethodCallConstraint.cs
@@ -5,12 +5,12 @@ namespace DivertR.Internal
     internal class MethodCallConstraint : ICallConstraint
     {
         private readonly IMethodConstraint _methodConstraint;
-        private readonly IArgumentConstraint[] _argumentConditions;
+        private readonly IArgumentConstraint[] _argumentConstraints;
 
-        public MethodCallConstraint(IMethodConstraint methodConstraint, IArgumentConstraint[] argumentConditions)
+        public MethodCallConstraint(IMethodConstraint methodConstraint, IArgumentConstraint[] argumentConstraints)
         {
             _methodConstraint = methodConstraint;
-            _argumentConditions = argumentConditions;
+            _argumentConstraints = argumentConstraints;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -21,14 +21,14 @@ namespace DivertR.Internal
                 return false;
             }
 
-            if (_argumentConditions.Length != callInfo.Arguments.Count)
+            if (_argumentConstraints.Length != callInfo.Arguments.Count)
             {
                 return false;
             }
 
-            for (var i = 0; i < _argumentConditions.Length; i++)
+            for (var i = 0; i < _argumentConstraints.Length; i++)
             {
-                if (!_argumentConditions[i].IsMatch(callInfo.Arguments[i]))
+                if (!_argumentConstraints[i].IsMatch(callInfo.Arguments[i]))
                 {
                     return false;
                 }

--- a/src/DivertR/Internal/TrueArgumentConstraint.cs
+++ b/src/DivertR/Internal/TrueArgumentConstraint.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace DivertR.Internal
+{
+    internal class TrueArgumentConstraint : IArgumentConstraint
+    {
+        public static readonly TrueArgumentConstraint Instance = new();
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsMatch(object? argument)
+        {
+            return true;
+        }
+    }
+}

--- a/src/DivertR/RedirectBuilder.cs
+++ b/src/DivertR/RedirectBuilder.cs
@@ -31,17 +31,17 @@ namespace DivertR
             return new ActionRedirectBuilder<TTarget>(callValidator, callConstraint.Of<TTarget>());
         }
 
-        public static IActionRedirectBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty?>> constraintExpression)
+        public static IActionRedirectBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty>>? constraintExpression = null)
         {
             if (memberExpression.Body == null) throw new ArgumentNullException(nameof(memberExpression));
-            if (constraintExpression.Body == null) throw new ArgumentNullException(nameof(constraintExpression));
+            if (constraintExpression is { Body: null }) throw new ArgumentNullException(nameof(constraintExpression));
 
             if (!(memberExpression.Body is MemberExpression propertyExpression))
             {
                 throw new ArgumentException("Must be a property member expression", nameof(memberExpression));
             }
 
-            var parsedCall = CallExpressionParser.FromPropertySetter(propertyExpression, constraintExpression.Body);
+            var parsedCall = CallExpressionParser.FromPropertySetter(propertyExpression, constraintExpression?.Body);
             var callConstraint = parsedCall.CreateCallConstraint();
 
             return new ActionRedirectBuilder<TTarget>(parsedCall, callConstraint.Of<TTarget>());

--- a/src/DivertR/Via.cs
+++ b/src/DivertR/Via.cs
@@ -157,7 +157,7 @@ namespace DivertR
             return new ActionViaBuilder<TTarget>(this, RedirectBuilder<TTarget>.To(constraintExpression));
         }
         
-        public IActionViaBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty?>> constraintExpression)
+        public IActionViaBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty>>? constraintExpression = null)
         {
             return new ActionViaBuilder<TTarget>(this, RedirectBuilder<TTarget>.ToSet(memberExpression, constraintExpression));
         }

--- a/test/DivertR.UnitTests/ViaRedirectTests.cs
+++ b/test/DivertR.UnitTests/ViaRedirectTests.cs
@@ -404,6 +404,22 @@ namespace DivertR.UnitTests
             // ASSERT
             result.ShouldBe("matched");
         }
+        
+        [Fact]
+        public void GivenSetPropertyRedirectWithNoValueConstraint_WhenValueMatches_ShouldRedirect()
+        {
+            // ARRANGE
+            _via
+                .ToSet(x => x.Name)
+                .Redirect<(string value, __)>(call => call.Relay.Root.Name = $"New {call.Args.value} set");
+
+            // ACT
+            var proxy = _via.Proxy(new Foo("hello foo"));
+            proxy.Name = "test";
+
+            // ASSERT
+            proxy.Name.ShouldBe("New test set");
+        }
 
         [Fact]
         public void GivenSetPropertyRedirect_WhenValueMatches_ShouldRedirect()


### PR DESCRIPTION
The Via `ToSet` method accepts a second parameter for matching the setter value for the call constraint. This change adds a null default to this parameter that matches any value.