### PR TITLE
Additional validation on Via To and ToSet expression input

### DIFF
--- a/src/DivertR/Internal/CallExpressionParser.cs
+++ b/src/DivertR/Internal/CallExpressionParser.cs
@@ -26,7 +26,7 @@ namespace DivertR.Internal
                 return FromProperty(memberExpression, null);
             }
 
-            throw new ArgumentException($"Only property MemberExpression valid but got: {expression.GetType()}", nameof(expression));
+            throw new ArgumentException($"Must be a property MemberExpression but got: {expression.GetType()}", nameof(expression));
         }
         
         public static ICallValidator FromPropertySetter(MemberExpression propertyExpression, Expression? valueExpression)
@@ -35,7 +35,7 @@ namespace DivertR.Internal
 
             if (propertyExpression.Member is not PropertyInfo property)
             {
-                throw new ArgumentException($"Member property must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
+                throw new ArgumentException($"The expression Member property must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
             }
             
             var methodInfo = property.GetSetMethod(true);
@@ -181,7 +181,7 @@ namespace DivertR.Internal
                 case MethodCallExpression callExpression
                     when callExpression.Method.DeclaringType?.FullName == "Moq.It":
                     {
-                        throw new ArgumentException("Moq.It argument syntax is not supported by DivertR");
+                        throw new ArgumentException("Moq.It argument match syntax is not supported by DivertR");
                     }
                 
                 default:

--- a/src/DivertR/Internal/CallExpressionParser.cs
+++ b/src/DivertR/Internal/CallExpressionParser.cs
@@ -9,14 +9,24 @@ namespace DivertR.Internal
 {
     internal static class CallExpressionParser
     {
-        public static ICallValidator FromExpression(Expression expression)
+        public static ICallValidator FromExpression<TTarget>(Expression expression)
         {
             return expression switch
             {
-                MethodCallExpression methodExpression => FromMethodCall(methodExpression),
-                MemberExpression propertyExpression => FromProperty(propertyExpression),
+                MethodCallExpression methodExpression => FromMethodCall(methodExpression, typeof(TTarget)),
+                MemberExpression propertyExpression => FromProperty(propertyExpression, typeof(TTarget)),
                 _ => throw new ArgumentException($"Invalid expression type: {expression.GetType()}", nameof(expression))
             };
+        }
+        
+        public static ICallValidator FromProperty(Expression expression)
+        {
+            if (expression is MemberExpression memberExpression)
+            {
+                return FromProperty(memberExpression, null);
+            }
+
+            throw new ArgumentException($"Only property MemberExpression valid but was: {expression.GetType()}", nameof(expression));
         }
         
         public static ICallValidator FromPropertySetter(MemberExpression propertyExpression, Expression? valueExpression)
@@ -38,23 +48,29 @@ namespace DivertR.Internal
             return new ExpressionCallValidator(methodInfo, parameterInfos, methodConstraint, argumentConstraints);
         }
         
-        private static ExpressionCallValidator FromMethodCall(MethodCallExpression methodExpression)
+        private static ExpressionCallValidator FromMethodCall(MethodCallExpression expression, Type targetType)
         {
-            var methodInfo = methodExpression.Method ?? throw new ArgumentNullException(nameof(methodExpression));
+            var methodInfo = expression.Method ?? throw new ArgumentNullException(nameof(expression));
+
+            if (methodInfo.DeclaringType == null || !methodInfo.DeclaringType.IsAssignableFrom(targetType))
+            {
+                throw new ArgumentException($"Declaring type of MethodCallExpression {methodInfo.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
+            }
+            
             var parameterInfos = methodInfo.GetParameters();
-            var argumentConstraints = CreateArgumentConstraints(parameterInfos, methodExpression.Arguments);
+            var argumentConstraints = CreateArgumentConstraints(parameterInfos, expression.Arguments);
             var methodConstraint = CreateMethodConstraint(methodInfo);
             
             return new ExpressionCallValidator(methodInfo, parameterInfos, methodConstraint, argumentConstraints);
         }
 
-        private static ICallValidator FromProperty(MemberExpression propertyExpression)
+        private static ICallValidator FromProperty(MemberExpression expression, Type? targetType)
         {
-            if (propertyExpression == null) throw new ArgumentNullException(nameof(propertyExpression));
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
             
-            if (propertyExpression.Member is not PropertyInfo property)
+            if (expression.Member is not PropertyInfo property)
             {
-                throw new ArgumentException($"Member expression must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
+                throw new ArgumentException($"Member expression must be of type PropertyInfo but got: {expression.Member.GetType()}", nameof(expression));
             }
 
             if (property.DeclaringType?.IsGenericType == true &&
@@ -62,10 +78,20 @@ namespace DivertR.Internal
             {
                 if (property.Name != nameof(Is<object>.Return))
                 {
-                    throw new ArgumentException($"Only the property Is<T>.{nameof(Is<object>.Return)} may be used as expression return value");
+                    throw new ArgumentException($"Only the property Is<T>.{nameof(Is<object>.Return)} may be used as an expression return value", nameof(expression));
                 }
                 
                 return new ReturnCallValidator(property.PropertyType);
+            }
+
+            if (targetType == null)
+            {
+                throw new ArgumentException($"Only the return value property Is<T>.{nameof(Is<object>.Return)} is valid here", nameof(expression));
+            }
+            
+            if (property.DeclaringType == null || !property.DeclaringType.IsAssignableFrom(targetType))
+            {
+                throw new ArgumentException($"Declaring type of MethodCallExpression {property.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
             }
             
             var methodInfo = property.GetGetMethod(true);
@@ -87,6 +113,33 @@ namespace DivertR.Internal
                 .ToArray();
         }
 
+        private static bool IsDiverterArgument(MemberInfo member, ParameterInfo parameterInfo)
+        {
+            if (member.DeclaringType is not { IsGenericType: true })
+            {
+                return false;
+            }
+
+            var typeDefinition = member.DeclaringType.GetGenericTypeDefinition();
+
+            if (typeDefinition == typeof(Is<>))
+            {
+                return true;
+            }
+
+            if (typeDefinition == typeof(IsRef<>))
+            {
+                if (!parameterInfo.ParameterType.IsByRef)
+                {
+                    throw new ArgumentException($"IsRef<T> argument used with parameter '{parameterInfo}' that is not ByRef");
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
         private static IArgumentConstraint CreateArgumentConstraint(ParameterInfo parameterInfo, Expression argument)
         {
             switch (argument)
@@ -95,20 +148,18 @@ namespace DivertR.Internal
                     return new ConstantArgumentConstraint(constantExpression.Value);
 
                 case MemberExpression memberExpression
-                    when memberExpression.Member.DeclaringType != null &&
-                         memberExpression.Member.DeclaringType.IsGenericType &&
-                         (memberExpression.Member.DeclaringType.GetGenericTypeDefinition() == typeof(Is<>) ||
-                          memberExpression.Member.DeclaringType.GetGenericTypeDefinition() == typeof(IsRef<>) &&
-                          parameterInfo.ParameterType.IsByRef) &&
-                         memberExpression.Member.Name == nameof(Is<object>.Any):
+                    when IsDiverterArgument(memberExpression.Member, parameterInfo):
                     {
-                        return BuildTypeMatchConstraint(memberExpression.Member.DeclaringType.GenericTypeArguments[0]);
+                        if (memberExpression.Member.Name != nameof(Is<object>.Any))
+                        {
+                            throw new ArgumentException($"Only the property Is<T>.{nameof(Is<object>.Any)} may be used in this context as a method argument value");
+                        }
+                        
+                        return BuildTypeMatchConstraint(memberExpression.Member.DeclaringType!.GenericTypeArguments[0]);
                     }
 
                 case MethodCallExpression callExpression
-                    when callExpression.Method.DeclaringType != null &&
-                         callExpression.Method.DeclaringType.IsGenericType &&
-                         callExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(Is<>) &&
+                    when IsDiverterArgument(callExpression.Method, parameterInfo) &&
                          callExpression.Arguments.Any() &&
                          callExpression.Arguments[0] is LambdaExpression lambdaExpression &&
                          lambdaExpression.ReturnType == typeof(bool):
@@ -117,10 +168,7 @@ namespace DivertR.Internal
                     }
                 
                 case MemberExpression { Expression: MethodCallExpression callExpression }
-                    when callExpression.Method.DeclaringType != null &&
-                         callExpression.Method.DeclaringType.IsGenericType &&
-                         callExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(IsRef<>) &&
-                         parameterInfo.ParameterType.IsByRef &&
+                    when IsDiverterArgument(callExpression.Method, parameterInfo) &&
                          callExpression.Type.IsGenericType && 
                          callExpression.Type.GetGenericTypeDefinition() == typeof(RefValue<>) &&
                          callExpression.Arguments.Any() &&
@@ -153,7 +201,7 @@ namespace DivertR.Internal
             return (IArgumentConstraint) Activator.CreateInstance(lambdaType, ActivatorFlags, null, new object[] { matchExpression }, default);
         }
         
-        private static readonly ConcurrentDictionary<Type, IArgumentConstraint> TypeMatchConstraintCache = new ConcurrentDictionary<Type, IArgumentConstraint>();
+        private static readonly ConcurrentDictionary<Type, IArgumentConstraint> TypeMatchConstraintCache = new();
         
         private static IArgumentConstraint BuildTypeMatchConstraint(Type argumentType)
         {

--- a/src/DivertR/Internal/CallExpressionParser.cs
+++ b/src/DivertR/Internal/CallExpressionParser.cs
@@ -26,7 +26,7 @@ namespace DivertR.Internal
                 return FromProperty(memberExpression, null);
             }
 
-            throw new ArgumentException($"Only property MemberExpression valid but was: {expression.GetType()}", nameof(expression));
+            throw new ArgumentException($"Only property MemberExpression valid but got: {expression.GetType()}", nameof(expression));
         }
         
         public static ICallValidator FromPropertySetter(MemberExpression propertyExpression, Expression? valueExpression)
@@ -35,7 +35,7 @@ namespace DivertR.Internal
 
             if (propertyExpression.Member is not PropertyInfo property)
             {
-                throw new ArgumentException($"Member expression must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
+                throw new ArgumentException($"Member property must be of type PropertyInfo but got: {propertyExpression.Member.GetType()}", nameof(propertyExpression));
             }
             
             var methodInfo = property.GetSetMethod(true);
@@ -54,7 +54,7 @@ namespace DivertR.Internal
 
             if (methodInfo.DeclaringType == null || !methodInfo.DeclaringType.IsAssignableFrom(targetType))
             {
-                throw new ArgumentException($"Declaring type of MethodCallExpression {methodInfo.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
+                throw new ArgumentException($"The method declaring type {methodInfo.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
             }
             
             var parameterInfos = methodInfo.GetParameters();
@@ -78,7 +78,7 @@ namespace DivertR.Internal
             {
                 if (property.Name != nameof(Is<object>.Return))
                 {
-                    throw new ArgumentException($"Only the property Is<T>.{nameof(Is<object>.Return)} may be used as an expression return value", nameof(expression));
+                    throw new ArgumentException($"Only Is<T>.{nameof(Is<object>.Return)} may be used as a return constraint property", nameof(expression));
                 }
                 
                 return new ReturnCallValidator(property.PropertyType);
@@ -86,12 +86,12 @@ namespace DivertR.Internal
 
             if (targetType == null)
             {
-                throw new ArgumentException($"Only the return value property Is<T>.{nameof(Is<object>.Return)} is valid here", nameof(expression));
+                throw new ArgumentException($"Only the property Is<T>.{nameof(Is<object>.Return)} may be used as a return constraint value in this context", nameof(expression));
             }
             
             if (property.DeclaringType == null || !property.DeclaringType.IsAssignableFrom(targetType))
             {
-                throw new ArgumentException($"Declaring type of MethodCallExpression {property.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
+                throw new ArgumentException($"The property declaring type {property.DeclaringType} is not assignable from the Via target type: {targetType}", nameof(expression));
             }
             
             var methodInfo = property.GetGetMethod(true);

--- a/src/DivertR/Record/Internal/RecordStream.cs
+++ b/src/DivertR/Record/Internal/RecordStream.cs
@@ -27,7 +27,7 @@ namespace DivertR.Record.Internal
         {
             if (lambdaExpression.Body == null) throw new ArgumentNullException(nameof(lambdaExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(lambdaExpression.Body);
+            var callValidator = CallExpressionParser.FromExpression<TTarget>(lambdaExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             var calls = Calls
                 .Where(x => callConstraint.IsMatch(x.CallInfo))
@@ -40,7 +40,7 @@ namespace DivertR.Record.Internal
         {
             if (lambdaExpression.Body == null) throw new ArgumentNullException(nameof(lambdaExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(lambdaExpression.Body);
+            var callValidator = CallExpressionParser.FromExpression<TTarget>(lambdaExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             var calls = Calls.Where(x => callConstraint.IsMatch(x.CallInfo));
 
@@ -100,7 +100,7 @@ namespace DivertR.Record.Internal
         {
             if (constraintExpression.Body == null) throw new ArgumentNullException(nameof(constraintExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(constraintExpression.Body);
+            var callValidator = CallExpressionParser.FromProperty(constraintExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             
             var calls = Calls

--- a/src/DivertR/RedirectBuilder.cs
+++ b/src/DivertR/RedirectBuilder.cs
@@ -15,7 +15,7 @@ namespace DivertR
         {
             if (constraintExpression.Body == null) throw new ArgumentNullException(nameof(constraintExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(constraintExpression.Body);
+            var callValidator = CallExpressionParser.FromExpression<TTarget>(constraintExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             
             return new FuncRedirectBuilder<TTarget, TReturn>(callValidator, callConstraint.Of<TTarget>());
@@ -25,7 +25,7 @@ namespace DivertR
         {
             if (constraintExpression.Body == null) throw new ArgumentNullException(nameof(constraintExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(constraintExpression.Body);
+            var callValidator = CallExpressionParser.FromExpression<TTarget>(constraintExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             
             return new ActionRedirectBuilder<TTarget>(callValidator, callConstraint.Of<TTarget>());
@@ -59,7 +59,7 @@ namespace DivertR
         {
             if (constraintExpression.Body == null) throw new ArgumentNullException(nameof(constraintExpression));
 
-            var callValidator = CallExpressionParser.FromExpression(constraintExpression.Body);
+            var callValidator = CallExpressionParser.FromProperty(constraintExpression.Body);
             var callConstraint = callValidator.CreateCallConstraint();
             
             return new FuncRedirectBuilder<TReturn>(callConstraint);

--- a/test/DivertR.UnitTests/ViaTests.cs
+++ b/test/DivertR.UnitTests/ViaTests.cs
@@ -1,0 +1,79 @@
+using System;
+using DivertR.UnitTests.Model;
+using Shouldly;
+using Xunit;
+
+namespace DivertR.UnitTests
+{
+    public class ViaTests
+    {
+        private readonly IVia<IFoo> _via = new Via<IFoo>();
+
+        [Fact]
+        public void GivenNoRedirects_ShouldDefaultToRoot()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var proxy = _via.Proxy(original);
+
+            // ACT
+            var name = proxy.Name;
+
+            // ASSERT
+            name.ShouldBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenValidRootObjectType_WhenCreateProxyObject_ShouldCreateProxy()
+        {
+            // ARRANGE
+            var original = new Foo();
+
+            // ACT
+            var proxy = (IFoo) ((IVia) _via).Proxy(original);
+
+            // ASSERT
+            proxy.Name.ShouldBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenProxyWithNullRoot_WhenProxyMemberCalled_ShouldThrowException()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(null);
+
+            // ACT
+            Func<object> testAction = () => proxy.Name;
+
+            // ASSERT
+            testAction.ShouldThrow<DiverterNullRootException>();
+        }
+        
+        [Fact]
+        public void GivenInvalidRootObjectType_WhenCreateProxyObject_ShouldThrowArgumentException()
+        {
+            // ARRANGE
+            var invalidOriginal = new object();
+
+            // ACT
+            Func<object> testAction = () => _via.Proxy(invalidOriginal);
+
+            // ASSERT
+            testAction.ShouldThrow<ArgumentException>();
+        }
+
+        [Fact]
+        public void GivenStrictModeWithNoRedirect_ShouldThrowException()
+        {
+            // ARRANGE
+            _via.Strict();
+            var proxy = _via.Proxy(new Foo("hello foo"));
+
+            // ACT
+            Func<string> testAction = () => proxy.Name;
+
+            // ASSERT
+            testAction.ShouldThrow<DiverterException>();
+        }
+    }
+}


### PR DESCRIPTION
Additional validation for stricter checking of Via `To` and `ToSet` expression input.

- Ensure expression Method or Property must be acting on the Via Target type
- Better checking of return type expressions
- Stricter validation around `IsRef` argument usage.