### PR TITLE
Add Redirect method to Via

### DIFF
--- a/src/DivertR/IVia.cs
+++ b/src/DivertR/IVia.cs
@@ -56,7 +56,7 @@ namespace DivertR
         /// </summary>
         /// <param name="redirect">The redirect instance.</param>
         /// <param name="optionsAction">Optional redirect options builder action.</param>
-        /// <returns></returns>
+        /// <returns>The current <see cref="IVia"/> instance.</returns>
         IVia Redirect(IRedirect redirect, Action<IRedirectOptionsBuilder>? optionsAction = null);
 
         /// <summary>
@@ -115,6 +115,31 @@ namespace DivertR
         /// <returns>The proxy instance.</returns>
         [return: NotNull]
         new TTarget Proxy();
+        
+        /// <summary>
+        /// Insert a redirect into this Via.
+        /// </summary>
+        /// <param name="redirect">The redirect instance.</param>
+        /// <param name="optionsAction">Optional redirect options builder action.</param>
+        /// <returns>The current <see cref="IVia{TTarget}"/> instance.</returns>
+        new IVia<TTarget> Redirect(IRedirect redirect, Action<IRedirectOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Create and insert a redirect (with no <see cref="ICallConstraint{TTarget}"/>) to the given <paramref name="target"/>
+        /// into the Via <see cref="IRedirectRepository" />.
+        /// </summary>
+        /// <param name="target">The target instance to redirect call to.</param>
+        /// <param name="optionsAction">An optional builder action for configuring redirect options.</param>
+        /// <returns>The current <see cref="IVia{TTarget}"/> instance.</returns>
+        IVia<TTarget> Retarget(TTarget target, Action<IRedirectOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Inserts a redirect that captures incoming calls from all proxies.
+        /// By default record redirects are configured to not satisfy strict calls if strict mode is enabled.
+        /// </summary>
+        /// <param name="optionsAction">An optional builder action for configuring redirect options.</param>
+        /// <returns>An <see cref="IRecordStream{TTarget}"/> reference for retrieving and iterating the recorded calls.</returns>
+        IRecordStream<TTarget> Record(Action<IRedirectOptionsBuilder>? optionsAction = null);
 
         /// <summary>
         /// Reset the Via <see cref="IRedirectRepository" />.
@@ -129,23 +154,6 @@ namespace DivertR
         /// <returns>The current <see cref="IVia{TTarget}"/> instance.</returns>
         new IVia<TTarget> Strict(bool? isStrict = true);
 
-        /// <summary>
-        /// Create and insert a redirect (with no <see cref="ICallConstraint{TTarget}"/>) to the given <paramref name="target"/>
-        /// into the Via <see cref="IRedirectRepository" />.
-        /// </summary>
-        /// <param name="target">The target instance to redirect call to.</param>
-        /// <param name="optionsAction">An optional builder action for configuring redirect options.</param>
-        /// <returns>The Redirect builder instance.</returns>
-        IViaBuilder<TTarget> Retarget(TTarget target, Action<IRedirectOptionsBuilder>? optionsAction = null);
-        
-        /// <summary>
-        /// Inserts a redirect that captures incoming calls from all proxies.
-        /// By default record redirects are configured to not satisfy strict calls if strict mode is enabled.
-        /// </summary>
-        /// <param name="optionsAction">An optional builder action for configuring redirect options.</param>
-        /// <returns>An <see cref="IRecordStream{TTarget}"/> reference for retrieving and iterating the recorded calls.</returns>
-        IRecordStream<TTarget> Record(Action<IRedirectOptionsBuilder>? optionsAction = null);
-        
         /// <summary>
         /// Creates a Redirect builder. />
         /// </summary>

--- a/src/DivertR/Via.cs
+++ b/src/DivertR/Via.cs
@@ -108,12 +108,17 @@ namespace DivertR
             return Proxy(ViaSet.Settings.DefaultWithDummyRoot);
         }
         
-        public IVia Redirect(IRedirect redirect, Action<IRedirectOptionsBuilder>? optionsAction = null)
+        public IVia<TTarget> Redirect(IRedirect redirect, Action<IRedirectOptionsBuilder>? optionsAction = null)
         {
             var options = RedirectOptionsBuilder.Create(optionsAction);
             RedirectRepository.InsertRedirect(redirect, options);
 
             return this;
+        }
+        
+        IVia IVia.Redirect(IRedirect redirect, Action<IRedirectOptionsBuilder>? optionsAction)
+        {
+            return Redirect(redirect, optionsAction);
         }
 
         IVia IVia.Reset()
@@ -140,9 +145,11 @@ namespace DivertR
             return this;
         }
         
-        public IViaBuilder<TTarget> Retarget(TTarget target, Action<IRedirectOptionsBuilder>? optionsAction = null)
+        public IVia<TTarget> Retarget(TTarget target, Action<IRedirectOptionsBuilder>? optionsAction = null)
         {
-            return To().Retarget(target, optionsAction);
+            To().Retarget(target, optionsAction);
+
+            return this;
         }
         
         public IRecordStream<TTarget> Record(Action<IRedirectOptionsBuilder>? optionsAction = null)

--- a/test/DivertR.UnitTests/ViaRedirectTests.cs
+++ b/test/DivertR.UnitTests/ViaRedirectTests.cs
@@ -1,0 +1,101 @@
+﻿using System.Linq;
+using DivertR.UnitTests.Model;
+using Shouldly;
+using Xunit;
+
+namespace DivertR.UnitTests;
+
+public class ViaRedirectTests
+{
+    [Fact]
+    public void GivenRedirect_WhenRedirectAddedToVia_ThenRedirectProxyCalls()
+    {
+        // ARRANGE
+        var redirect = RedirectBuilder<IFoo>
+            .To(x => x.Name)
+            .Build(call => call.CallNext() + " diverted");
+        
+        // ACT
+        var foo = Via.Proxy<IFoo>(new Foo("MrFoo"));
+        Via.From(foo).Redirect(redirect);
+        
+        // ASSERT
+        foo.Name.ShouldBe("MrFoo diverted");
+    }
+    
+    [Fact]
+    public void GivenRedirect_WhenRedirectWithOptionsAddedToVia_ThenRedirectProxyCalls()
+    {
+        // ARRANGE
+        var redirect = RedirectBuilder<IFoo>
+            .To(x => x.Name)
+            .Build(call => call.CallNext() + " diverted");
+        
+        // ACT
+        var foo = Via.Proxy<IFoo>(new Foo("MrFoo"));
+        Via.From(foo).Redirect(redirect, opt => opt.Repeat(1));
+        
+        // ASSERT
+        foo.Name.ShouldBe("MrFoo diverted");
+        foo.Name.ShouldBe("MrFoo");
+    }
+
+    [Fact]
+    public void GivenRedirect_WhenRedirectAddedToNonTypedVia_ThenRedirectProxyCalls()
+    {
+        // ARRANGE
+        var redirect = RedirectBuilder<IFoo>
+            .To(x => x.Name)
+            .Build(call => call.CallNext() + " diverted");
+        
+        // ACT
+        var foo = Via.Proxy<IFoo>(new Foo("MrFoo"));
+        IVia via = Via.From(foo);
+        via.Redirect(redirect);
+        
+        // ASSERT
+        foo.Name.ShouldBe("MrFoo diverted");
+    }
+    
+    [Fact]
+    public void GivenRedirect_WhenRedirectWithOptionsAddedToNonTypedVia_ThenRedirectProxyCalls()
+    {
+        // ARRANGE
+        var redirect = RedirectBuilder<IFoo>
+            .To(x => x.Name)
+            .Build(call => call.CallNext() + " diverted");
+        
+        // ACT
+        var foo = Via.Proxy<IFoo>(new Foo("MrFoo"));
+        IVia via = Via.From(foo);
+        via.Redirect(redirect, opt => opt.Repeat(1));
+        
+        // ASSERT
+        foo.Name.ShouldBe("MrFoo diverted");
+        foo.Name.ShouldBe("MrFoo");
+    }
+    
+    [Fact]
+    public void GivenRedirectWithChainedRecord_WhenProxyCalled_ThenRecordsCalls()
+    {
+        // ARRANGE
+        var redirect = RedirectBuilder<IFoo>
+            .To(x => x.Name)
+            .Build(call => call.CallNext() + " diverted");
+        
+        var foo = Via.Proxy<IFoo>(new Foo("MrFoo"));
+        var fooCalls = Via.From(foo)
+            .Redirect(redirect, opt => opt.Repeat(1))
+            .Record();
+        
+        // ACT
+        var names = Enumerable.Range(0, 2).Select(_ => foo.Name).ToArray();
+        
+        // ASSERT
+        fooCalls
+            .To(x => x.Name)
+            .Verify()
+            .Select(x => x.Returned!.Value)
+            .ShouldBe(names);
+    }
+}


### PR DESCRIPTION
Add Redirect method to the Via interface that allows adding an `IRedirect` instance directly to the Via.