### PR TITLE
Add all Via generated proxies to static map by settings decorator

### DIFF
--- a/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
@@ -74,7 +74,7 @@ namespace DivertR.DependencyInjection
             {
                 var root = rootFactory.Invoke(provider);
                 
-                return via.ViaSet.Settings.ViaProxyDecorator.Decorate(via, root);
+                return via.ViaSet.Settings.DiverterProxyDecorator.Decorate(via, root);
             };
         }
         

--- a/src/DivertR/DiverterSettings.cs
+++ b/src/DivertR/DiverterSettings.cs
@@ -12,7 +12,11 @@ namespace DivertR
         
         
         public IProxyFactory ProxyFactory { get; }
+        
+        public IProxyViaMap ProxyViaMap { get; }
 
+        public IDiverterProxyDecorator DiverterProxyDecorator { get; }
+        
         public IViaProxyDecorator ViaProxyDecorator { get; }
         
         public bool DefaultWithDummyRoot { get; }
@@ -43,13 +47,17 @@ namespace DivertR
 
         public DiverterSettings(
             IProxyFactory? proxyFactory = null,
-            IViaProxyDecorator? dependencyFactory = null,
+            IProxyViaMap? proxyViaMap = null,
+            IDiverterProxyDecorator? diverterProxyDecorator = null,
+            IViaProxyDecorator? viaProxyDecorator = null,
             bool defaultWithDummyRoot = true,
             IDummyFactory? dummyFactory = null,
             ICallInvoker? callInvoker = null)
         {
             ProxyFactory = proxyFactory ?? new DispatchProxyFactory();
-            ViaProxyDecorator = dependencyFactory ?? new ViaProxyDecorator();
+            ProxyViaMap = proxyViaMap ?? Via.ProxyViaMap;
+            DiverterProxyDecorator = diverterProxyDecorator ?? new DiverterProxyDecorator();
+            ViaProxyDecorator = viaProxyDecorator ?? new ViaProxyDecorator(ProxyViaMap);
             DefaultWithDummyRoot = defaultWithDummyRoot;
             DummyFactory = dummyFactory ?? new DummyFactory();
             CallInvoker = callInvoker ?? DefaultCallInvoker;

--- a/src/DivertR/IDiverterProxyDecorator.cs
+++ b/src/DivertR/IDiverterProxyDecorator.cs
@@ -1,0 +1,7 @@
+﻿namespace DivertR
+{
+    public interface IDiverterProxyDecorator
+    {
+        object? Decorate(IVia via, object? original);
+    }
+}

--- a/src/DivertR/IProxyViaMap.cs
+++ b/src/DivertR/IProxyViaMap.cs
@@ -1,0 +1,8 @@
+﻿namespace DivertR
+{
+    public interface IProxyViaMap
+    {
+        void AddVia(IVia via, object proxy);
+        IVia<TTarget> GetVia<TTarget>(TTarget proxy) where TTarget : class;
+    }
+}

--- a/src/DivertR/IViaProxyDecorator.cs
+++ b/src/DivertR/IViaProxyDecorator.cs
@@ -1,7 +1,10 @@
-﻿namespace DivertR
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace DivertR
 {
     public interface IViaProxyDecorator
     {
-        object? Decorate(IVia via, object? original);
+        [return: NotNull]
+        TTarget Decorate<TTarget>(IVia via, [DisallowNull] TTarget proxy) where TTarget : class?;
     }
 }

--- a/src/DivertR/Internal/DiverterProxyDecorator.cs
+++ b/src/DivertR/Internal/DiverterProxyDecorator.cs
@@ -1,0 +1,15 @@
+﻿namespace DivertR.Internal
+{
+    internal class DiverterProxyDecorator : IDiverterProxyDecorator
+    {
+        public object? Decorate(IVia via, object? original)
+        {
+            if (original == null)
+            {
+                return null;
+            }
+
+            return via.Proxy(original);
+        }
+    }
+}

--- a/src/DivertR/Internal/ProxyViaMap.cs
+++ b/src/DivertR/Internal/ProxyViaMap.cs
@@ -2,11 +2,11 @@
 
 namespace DivertR.Internal
 {
-    internal class ProxyViaMap
+    internal class ProxyViaMap : IProxyViaMap
     {
         private readonly ConditionalWeakTable<object, IVia> _viaMap = new();
 
-        public void AddVia(object proxy, IVia via)
+        public void AddVia(IVia via, object proxy)
         {
             _viaMap.Add(proxy, via);
         }

--- a/src/DivertR/Internal/ViaProxyDecorator.cs
+++ b/src/DivertR/Internal/ViaProxyDecorator.cs
@@ -1,15 +1,22 @@
-﻿namespace DivertR.Internal
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace DivertR.Internal
 {
     internal class ViaProxyDecorator : IViaProxyDecorator
     {
-        public object? Decorate(IVia via, object? original)
-        {
-            if (original == null)
-            {
-                return null;
-            }
+        private readonly IProxyViaMap _proxyViaMap;
 
-            return via.Proxy(original);
+        public ViaProxyDecorator(IProxyViaMap proxyViaMap)
+        {
+            _proxyViaMap = proxyViaMap;
+        }
+        
+        [return: NotNull]
+        public TTarget Decorate<TTarget>(IVia via, [DisallowNull] TTarget proxy) where TTarget : class?
+        {
+            _proxyViaMap.AddVia(via, proxy);
+            
+            return proxy;
         }
     }
 }

--- a/src/DivertR/Via.cs
+++ b/src/DivertR/Via.cs
@@ -91,7 +91,9 @@ namespace DivertR
         [return: NotNull]
         public TTarget Proxy(TTarget? root)
         {
-            return _proxyFactory.CreateProxy(_viaProxyCall, root);
+            var proxy = _proxyFactory.CreateProxy(_viaProxyCall, root);
+            
+            return ViaSet.Settings.ViaProxyDecorator.Decorate(this, proxy);
         }
         
         [return: NotNull]
@@ -180,7 +182,7 @@ namespace DivertR
 
     public static class Via
     {
-        private static readonly ProxyViaMap ProxyViaMap = new();
+        internal static readonly ProxyViaMap ProxyViaMap = new();
         
         /// <summary>
         /// Creates a Via proxy instance.
@@ -230,10 +232,8 @@ namespace DivertR
         private static TTarget Proxy<TTarget>(Func<Via<TTarget>, TTarget> createProxy) where TTarget : class?
         {
             var via = new Via<TTarget>();
-            var proxy = createProxy(via);
-            ProxyViaMap.AddVia(proxy!, via);
-
-            return proxy;
+            
+            return createProxy(via);
         }
     }
 }

--- a/test/DivertR.UnitTests/ViaProxyTests.cs
+++ b/test/DivertR.UnitTests/ViaProxyTests.cs
@@ -73,6 +73,20 @@ namespace DivertR.UnitTests
         }
         
         [Fact]
+        public void GivenNonStaticallyCreatedViaProxy_WhenStaticViaFrom_ShouldReturnVia()
+        {
+            // ARRANGE
+            var via = new Via<IFoo>();
+            var proxy = via.Proxy(new Foo());
+            
+            // ACT
+            var fromVia = Via.From(proxy);
+
+            // ASSERT
+            fromVia.ShouldBeSameAs(via);
+        }
+        
+        [Fact]
         public void GivenStaticViaProxyWithStaticallyCreatedRedirect_WhenProxyCalled_ShouldRedirect()
         {
             // ARRANGE


### PR DESCRIPTION
The ability to statically lookup a Via instance by proxy object was previously added here #21. 

However, mappings were only added when proxies were created from the static `Via.Proxy` methods.

This change adds a decorator that gets called when proxies are generated by all Vias. The decorator adds static Via lookup mappings on all proxies by default and can be customised on `DiverterSettings`. 