### PR TITLE
Update DynamicProxy factory to copy root fields when creating class proxies

### DIFF
--- a/src/DivertR.DynamicProxy/CustomProxyGenerator.cs
+++ b/src/DivertR.DynamicProxy/CustomProxyGenerator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Castle.DynamicProxy;
+
+namespace DivertR.DynamicProxy
+{
+    public class CustomProxyGenerator : ProxyGenerator
+    {
+        public TTarget CreateClassProxyWithRootFields<TTarget>(TTarget root, params IInterceptor[] interceptors) where TTarget : class?
+        {
+            var hasEmptyConstructor = typeof(TTarget).GetConstructor(Type.EmptyTypes) != null;
+
+            if (hasEmptyConstructor || !TryCreateUninitializedClassProxy(interceptors, out TTarget proxy))
+            {
+                proxy = CreateClassProxy<TTarget>(interceptors);
+            }
+            
+            CopyFields(root, proxy);
+
+            return proxy;
+        }
+        
+        private bool TryCreateUninitializedClassProxy<TTarget>(IInterceptor[] interceptors, out TTarget proxy) where TTarget : class?
+        {
+            var proxyType = CreateClassProxyType(typeof(TTarget), null, ProxyGenerationOptions.Default);
+            proxy = (TTarget) FormatterServices.GetUninitializedObject(proxyType);
+            
+            return TrySetInterceptor(proxy, interceptors);
+        }
+
+        private static bool TrySetInterceptor(object proxy, IInterceptor[] interceptors)
+        {
+            var field = proxy.GetType().GetField("__interceptors", BindingFlags.Instance | BindingFlags.NonPublic);
+            
+            if (field == null)
+            {
+                return false;
+            }
+
+            field.SetValue(proxy, interceptors);
+
+            return true;
+        }
+        
+        private static void CopyFields<TTarget>(TTarget src, TTarget dest)
+        {
+            const BindingFlags FieldFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            
+            var currentType = typeof(TTarget);
+
+            while (currentType != null && currentType != typeof(object))
+            {
+                foreach (var field in currentType.GetFields(FieldFlags))
+                {
+                    var fieldValue = field.GetValue(src);
+                    field.SetValue(dest, fieldValue);
+                }
+                
+                currentType = currentType.BaseType;
+            }
+        }
+    }
+}

--- a/src/DivertR/Record/Internal/RecordStream.cs
+++ b/src/DivertR/Record/Internal/RecordStream.cs
@@ -52,12 +52,12 @@ namespace DivertR.Record.Internal
             if (lambdaExpression.Body == null) throw new ArgumentNullException(nameof(lambdaExpression));
             if (valueExpression.Body == null) throw new ArgumentNullException(nameof(valueExpression));
 
-            if (!(lambdaExpression.Body is MemberExpression propertyExpression))
+            if (lambdaExpression.Body is not MemberExpression propertyExpression)
             {
                 throw new ArgumentException("Must be a property member expression", nameof(propertyExpression));
             }
 
-            var parsedCall = CallExpressionParser.FromPropertySetter(propertyExpression, valueExpression.Body);
+            var parsedCall = CallExpressionParser.FromPropertySetter<TTarget>(propertyExpression, valueExpression.Body);
             var callConstraint = parsedCall.CreateCallConstraint();
             var calls = Calls.Where(x => callConstraint.IsMatch(x.CallInfo));
 

--- a/src/DivertR/RedirectBuilder.cs
+++ b/src/DivertR/RedirectBuilder.cs
@@ -43,7 +43,7 @@ namespace DivertR
                 throw new ArgumentException("Must be a property member expression", nameof(memberExpression));
             }
 
-            var parsedCall = CallExpressionParser.FromPropertySetter(propertyExpression, constraintExpression.Body);
+            var parsedCall = CallExpressionParser.FromPropertySetter<TTarget>(propertyExpression, constraintExpression.Body);
             var callConstraint = new CallConstraintWrapper<TTarget>(parsedCall.CreateCallConstraint());
 
             return new ActionRedirectBuilder<TTarget>(parsedCall, callConstraint);

--- a/test/DivertR.UnitTests/ByRefInTests.cs
+++ b/test/DivertR.UnitTests/ByRefInTests.cs
@@ -1,5 +1,4 @@
-﻿using DivertR.DynamicProxy;
-using DivertR.UnitTests.Model;
+﻿using DivertR.UnitTests.Model;
 using Shouldly;
 using Xunit;
 
@@ -12,7 +11,7 @@ namespace DivertR.UnitTests
 #else
         // Due to a known issue DispatchProxy does not support in byref parameters prior to .NET 6
         // https://github.com/dotnet/runtime/issues/47522
-        private static readonly DiverterSettings DiverterSettings = new(proxyFactory: new DynamicProxyFactory());
+        private static readonly DiverterSettings DiverterSettings = new(proxyFactory: new DynamicProxy.DynamicProxyFactory());
 #endif
         private readonly IVia<INumberIn> _via = new ViaSet(DiverterSettings).Via<INumberIn>();
 

--- a/test/DivertR.UnitTests/Model/Foo.cs
+++ b/test/DivertR.UnitTests/Model/Foo.cs
@@ -5,6 +5,8 @@ namespace DivertR.UnitTests.Model
 {
     public class Foo : IFoo
     {
+        private readonly string _createdName;
+        
         public Foo() : this("original")
         {
         }
@@ -12,11 +14,17 @@ namespace DivertR.UnitTests.Model
         public Foo(string name)
         {
             Name = name;
+            _createdName = name;
+            CreatedName = name;
         }
 
         public string Name { get; set; }
 
         public object? LastAction { get; set; }
+
+        public string CreatedNameBacked => _createdName;
+
+        public string CreatedName { get; }
 
         public virtual string NameVirtual
         {

--- a/test/DivertR.UnitTests/Model/Foo.cs
+++ b/test/DivertR.UnitTests/Model/Foo.cs
@@ -6,6 +6,7 @@ namespace DivertR.UnitTests.Model
     public class Foo : IFoo
     {
         private readonly string _createdName;
+        public string? _publicField;
         
         public Foo() : this("original")
         {

--- a/test/DivertR.UnitTests/ViaBuilderTests.cs
+++ b/test/DivertR.UnitTests/ViaBuilderTests.cs
@@ -460,7 +460,7 @@ namespace DivertR.UnitTests
         }
         
         [Fact]
-        public void GivenVia_WhenToSetBuilderWithIsRefAnyConstraint_ThenThrowsArgumentException()
+        public void GivenVia_WhenToSetBuilderWithIsRefAnyConstraint_ThenThrowsException()
         {
             // ARRANGE
 
@@ -468,11 +468,11 @@ namespace DivertR.UnitTests
             var testAction = () => _via.ToSet(x => x.Name, () => IsRef<string>.Any);
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
-        public void GivenVia_WhenToSetBuilderWithIsRefMatchConstraint_ThenThrowsArgumentException()
+        public void GivenVia_WhenToSetBuilderWithIsRefMatchConstraint_ThenThrowsException()
         {
             // ARRANGE
 
@@ -480,7 +480,7 @@ namespace DivertR.UnitTests
             var testAction = () => _via.ToSet(x => x.Name, () => IsRef<string>.Match(m => true).Value);
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
@@ -988,7 +988,7 @@ namespace DivertR.UnitTests
         }
         
         [Fact]
-        public void GivenVia_WhenAddRedirectWithReturnMatchParameter_ThenThrowsArgumentException()
+        public void GivenVia_WhenAddRedirectWithReturnMatchParameter_ThenThrowsException()
         {
             // ARRANGE
 
@@ -996,11 +996,11 @@ namespace DivertR.UnitTests
             var testAction = () => _via.To(x => x.Echo(Is<string>.Return));
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
-        public void GivenVia_WhenAddRedirectWithIsRefAnyParameter_ThenThrowsArgumentException()
+        public void GivenVia_WhenAddRedirectWithIsRefAnyParameter_ThenThrowsException()
         {
             // ARRANGE
 
@@ -1008,11 +1008,11 @@ namespace DivertR.UnitTests
             var testAction = () => _via.To(x => x.Echo(IsRef<string>.Any));
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
-        public void GivenVia_WhenAddRedirectWithIsRefMatchParameter_ThenThrowsArgumentException()
+        public void GivenVia_WhenAddRedirectWithIsRefMatchParameter_ThenThrowsException()
         {
             // ARRANGE
 
@@ -1020,7 +1020,7 @@ namespace DivertR.UnitTests
             var testAction = () => _via.To(x => x.Echo(IsRef<string>.Match(m => true).Value));
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
 
         [Fact]
@@ -1105,7 +1105,7 @@ namespace DivertR.UnitTests
             Action testAction = () => _via.To(x => x.Echo(It.IsAny<string>()));
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
@@ -1117,7 +1117,7 @@ namespace DivertR.UnitTests
             Action testAction = () => _via.To(x => x.Echo(It.Is<string>(m => true)));
 
             // ASSERT
-            testAction.ShouldThrow<ArgumentException>();
+            testAction.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]

--- a/test/DivertR.UnitTests/ViaClassTests.cs
+++ b/test/DivertR.UnitTests/ViaClassTests.cs
@@ -146,5 +146,32 @@ namespace DivertR.UnitTests
             // ASSERT
             testAction.ShouldThrow<DiverterValidationException>();
         }
+        
+        [Fact]
+        public void GivenClassProxy_WhenProxyDerivedClass_ShouldCopyPrivateField()
+        {
+            // ARRANGE
+            var original = new DerivedFoo("hello foo", "other");
+            original._publicField = "test";
+            var via = new Via<DerivedFoo>(new DiverterSettings(proxyFactory: new DynamicProxyFactory()));
+
+            // ACT
+            var proxy = via.Proxy(original);
+
+            // ASSERT
+            proxy.CreatedName.ShouldBe(original.CreatedName);
+            proxy.AltName.ShouldBe(original.AltName);
+            proxy._publicField.ShouldBe(original._publicField);
+        }
+
+        public class DerivedFoo : Foo
+        {
+            public DerivedFoo(string name, string altName) : base(name)
+            {
+                AltName = altName;
+            }
+            
+            public string AltName { get; }
+        }
     }
 }

--- a/test/DivertR.UnitTests/ViaClassTests.cs
+++ b/test/DivertR.UnitTests/ViaClassTests.cs
@@ -29,7 +29,7 @@ namespace DivertR.UnitTests
             // ASSERT
             message.ShouldBe(original.Name);
         }
-        
+
         [Fact]
         public void GivenClassProxy_WhenTargetRedirect_ShouldDivert()
         {
@@ -55,6 +55,96 @@ namespace DivertR.UnitTests
 
             // ASSERT
             proxy.NameVirtual.ShouldBe("hello foo bar");
+        }
+        
+        [Fact]
+        public void GivenClassProxy_ShouldCopyProperty()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+
+            // ACT
+            var proxy = _via.Proxy(original);
+
+            // ASSERT
+            proxy.Name.ShouldBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenClassProxy_ShouldCopyBackingField()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+
+            // ACT
+            var proxy = _via.Proxy(original);
+
+            // ASSERT
+            proxy.CreatedNameBacked.ShouldBe(original.CreatedNameBacked);
+        }
+        
+        [Fact]
+        public void GivenClassProxy_ShouldCopyGetOnlyProperty()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+
+            // ACT
+            var proxy = _via.Proxy(original);
+
+            // ASSERT
+            proxy.CreatedName.ShouldBe(original.CreatedName);
+        }
+        
+        [Fact]
+        public void GivenClassProxy_WhenCopyFieldsDisabled_ShouldNotCopyPropertyBackingField()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var via = new Via<Foo>(new DiverterSettings(proxyFactory: new DynamicProxyFactory(copyRootFields: false)));
+
+            // ACT
+            var proxy = via.Proxy(original);
+
+            // ASSERT
+            proxy.Name.ShouldBe((new Foo()).Name);
+            proxy.Name.ShouldNotBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenClassProxy_WhenAddRedirectToNonVirtualGetter_ShouldThrowException()
+        {
+            // ARRANGE
+
+            // ACT
+            var testAction = () => _via.To(x => x.Name);
+
+            // ASSERT
+            testAction.ShouldThrow<DiverterValidationException>();
+        }
+        
+        [Fact]
+        public void GivenClassProxy_WhenAddRedirectToNonVirtualSetter_ShouldThrowException()
+        {
+            // ARRANGE
+
+            // ACT
+            var testAction = () => _via.ToSet(x => x.Name);
+
+            // ASSERT
+            testAction.ShouldThrow<DiverterValidationException>();
+        }
+        
+        [Fact]
+        public void GivenClassProxy_WhenAddRedirectToNonVirtualMethod_ShouldThrowException()
+        {
+            // ARRANGE
+
+            // ACT
+            var testAction = () => _via.To(x => x.Echo(Is<string>.Any));
+
+            // ASSERT
+            testAction.ShouldThrow<DiverterValidationException>();
         }
     }
 }


### PR DESCRIPTION
Update DynamicProxy proxy factory to copy root fields to generated class proxies.

It is only possible to intercept members that can be overridden on class proxies. This causes a problem with DivertR class proxies when a non-virtual proxy method is called as it does not forward to the root and will instead be invoked on the proxy instance. This means DivertR class proxy behaviour is not always the same as the root.

This change copies all root field values to the generated proxy when it is created. This is not a perfect solution to the problem above but can help in some scenarios to make the proxy behave more like the root. 