### PR TITLE
Add persistent redirect feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ For more examples and a demonstration of setting up a test harness for a WebApp 
 or follow below for a quickstart:
 
 * [Vias](./docs/Via.md) for creating and configuring proxies.
-* [Recording and Verifying](./docs/Verify.md) calls.
 * [Dependency Injection](./docs/DI.md) integration.
+* [Recording and Verifying](./docs/Verify.md) calls.
 * [About](./docs/About.md) DivertR.

--- a/src/DivertR.DynamicProxy/DivertR.DynamicProxy.csproj
+++ b/src/DivertR.DynamicProxy/DivertR.DynamicProxy.csproj
@@ -4,7 +4,7 @@
     <Title>DivertR.DynamicProxy</Title>
     <Authors>David Naylor</Authors>
     <Description>
-      A DivertR IProxyFactory implementation using Castle DynamicProxy with suuport for proxying class types.
+      A DivertR IProxyFactory implementation using Castle DynamicProxy with support for proxying class types.
       The in-built proxy factory is based on DispatchProxy and therefore only supports proxying interfaces. The proxy factory to use can be specified in DiverterSettings.
     </Description>
     <Copyright>MIT Copyright (c) David Naylor</Copyright>

--- a/src/DivertR/Diverter.cs
+++ b/src/DivertR/Diverter.cs
@@ -107,16 +107,16 @@ namespace DivertR
             return this;
         }
         
-        public IDiverter ResetAll()
+        public IDiverter ResetAll(bool includePersistent = false)
         {
-            ViaSet.ResetAll();
+            ViaSet.ResetAll(includePersistent);
             
             return this;
         }
 
-        public IDiverter Reset(string? name = null)
+        public IDiverter Reset(string? name = null, bool includePersistent = false)
         {
-            ViaSet.Reset(name);
+            ViaSet.Reset(name, includePersistent);
 
             return this;
         }

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -86,14 +86,16 @@ namespace DivertR
         /// <summary>
         /// Reset all registered <see cref="IVia" />s.
         /// </summary>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
         /// <returns>The current <see cref="IDiverter"/> instance.</returns>
-        IDiverter ResetAll();
+        IDiverter ResetAll(bool includePersistent = false);
         
         /// <summary>
         /// Reset registered <see cref="IVia" /> group.
         /// </summary>
         /// <param name="name">The Via group name.</param>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
         /// <returns>The current <see cref="IDiverter"/> instance.</returns>
-        IDiverter Reset(string? name = null);
+        IDiverter Reset(string? name = null, bool includePersistent = false);
     }
 }

--- a/src/DivertR/IRedirectOptions.cs
+++ b/src/DivertR/IRedirectOptions.cs
@@ -5,7 +5,8 @@ namespace DivertR
     public interface IRedirectOptions
     {
         int OrderWeight { get; }
-        bool DisableSatisfyStrict { get; }
+        bool DisableSatisfyStrict { get; }  
+        bool IsPersistent { get; }
         Func<IRedirect, IRedirect>? RedirectDecorator { get; }
     }
 }

--- a/src/DivertR/IRedirectOptionsBuilder.cs
+++ b/src/DivertR/IRedirectOptionsBuilder.cs
@@ -8,6 +8,7 @@ namespace DivertR
         IRedirectOptionsBuilder OrderFirst();
         IRedirectOptionsBuilder OrderLast();
         IRedirectOptionsBuilder DisableSatisfyStrict(bool disableStrict = true);
+        IRedirectOptionsBuilder Persist(bool isPersistent = true);
         
         IRedirectOptionsBuilder Decorate(Func<IRedirect, IRedirect> decorator);
         IRedirectOptionsBuilder Repeat(int repeatCount);

--- a/src/DivertR/IRedirectRepository.cs
+++ b/src/DivertR/IRedirectRepository.cs
@@ -26,6 +26,6 @@ namespace DivertR
         IRedirectRepository InsertRedirect(IRedirectContainer redirect);
         
         IRedirectRepository SetStrictMode(bool isStrict = true);
-        IRedirectRepository Reset();
+        IRedirectRepository Reset(bool includePersistent = false);
     }
 }

--- a/src/DivertR/IVia.cs
+++ b/src/DivertR/IVia.cs
@@ -72,8 +72,9 @@ namespace DivertR
         /// <summary>
         /// Reset the Via <see cref="IRedirectRepository" /> removing all configured redirects and disabling strict mode.
         /// </summary>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
         /// <returns>This Via instance.</returns>
-        IVia Reset();
+        IVia Reset(bool includePersistent = false);
 
         /// <summary>
         /// Set strict mode on the Via.
@@ -140,8 +141,9 @@ namespace DivertR
         /// <summary>
         /// Reset the Via <see cref="IRedirectRepository" /> removing all configured redirects and disabling strict mode.
         /// </summary>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
         /// <returns>This Via instance.</returns>
-        new IVia<TTarget> Reset();
+        new IVia<TTarget> Reset(bool includePersistent = false);
         
         /// <summary>
         /// Set strict mode on the Via.

--- a/src/DivertR/IViaSet.cs
+++ b/src/DivertR/IViaSet.cs
@@ -5,12 +5,49 @@ namespace DivertR
     public interface IViaSet
     {
         DiverterSettings Settings { get; }
+        
+        /// <summary>
+        /// Get or create a Via in this set for a given target type.
+        /// </summary>
+        /// <param name="name">Optional Via group name.</param>
+        /// <typeparam name="TTarget">The Via target type.</typeparam>
+        /// <returns>The existing or created Via.</returns>
         IVia<TTarget> Via<TTarget>(string? name = null) where TTarget : class?;
+        
+        /// <summary>
+        /// Get or create a Via in this set for a given target type.
+        /// </summary>
+        /// <param name="targetType">The Via target type.</param>
+        /// <param name="name">Optional Via group name.</param>
+        /// <returns>The existing or created Via.</returns>
         IVia Via(Type targetType, string? name = null);
-        IVia? Reset(ViaId viaId);
-        IViaSet Reset(string? name = null);
-        IViaSet ResetAll();
+
+        /// <summary>
+        /// Reset the specified group of <see cref="IVia" />s in this set.
+        /// </summary>
+        /// <param name="name">The Via group name.</param>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
+        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        IViaSet Reset(string? name = null, bool includePersistent = false);
+        
+        /// <summary>
+        /// Reset all <see cref="IVia" />s in this set.
+        /// </summary>
+        /// <param name="includePersistent">Optionally also reset persistent redirects.</param>
+        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        IViaSet ResetAll(bool includePersistent = false);
+        
+        /// <summary>
+        /// Enable strict mode on the specified group of <see cref="IVia" />s in this set.
+        /// </summary>
+        /// <param name="name">The Via group name.</param>
+        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
         IViaSet Strict(string? name = null);
+        
+        /// <summary>
+        /// Enable strict mode on all <see cref="IVia" />s in this set.
+        /// </summary>
+        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
         IViaSet StrictAll();
     }
 }

--- a/src/DivertR/Internal/RedirectOptionsBuilder.cs
+++ b/src/DivertR/Internal/RedirectOptionsBuilder.cs
@@ -8,6 +8,7 @@ namespace DivertR.Internal
     {
         private int _orderWeight;
         private bool _disableSatisfyStrict;
+        private bool _isPersistent;
         
         private readonly ConcurrentStack<Func<IRedirect, IRedirect>> _redirectDecorators = new();
 
@@ -40,6 +41,13 @@ namespace DivertR.Internal
 
             return this;
         }
+        
+        public IRedirectOptionsBuilder Persist(bool isPersistent = true)
+        {
+            _isPersistent = isPersistent;
+
+            return this;
+        }
 
         public IRedirectOptionsBuilder Decorate(Func<IRedirect, IRedirect> decorator)
         {
@@ -68,7 +76,7 @@ namespace DivertR.Internal
         
         private IRedirectOptions BuildOptions()
         {
-            return new RedirectOptions(_orderWeight, _disableSatisfyStrict, BuildRedirectDecorator());
+            return new RedirectOptions(_orderWeight, _disableSatisfyStrict, _isPersistent, BuildRedirectDecorator());
         }
         
         private Func<IRedirect, IRedirect>? BuildRedirectDecorator()

--- a/src/DivertR/RedirectOptions.cs
+++ b/src/DivertR/RedirectOptions.cs
@@ -9,15 +9,18 @@ namespace DivertR
         public RedirectOptions(
             int orderWeight = 0,
             bool disableSatisfyStrict = false,
+            bool isPersistent = false,
             Func<IRedirect, IRedirect>? redirectDecorator = null)
         {
             OrderWeight = orderWeight;
             DisableSatisfyStrict = disableSatisfyStrict;
+            IsPersistent = isPersistent;
             RedirectDecorator = redirectDecorator;
         }
 
         public int OrderWeight { get; }
         public bool DisableSatisfyStrict { get; }
+        public bool IsPersistent { get; }
         public Func<IRedirect, IRedirect>? RedirectDecorator { get; }
     }
 }

--- a/src/DivertR/Via.cs
+++ b/src/DivertR/Via.cs
@@ -123,9 +123,9 @@ namespace DivertR
             return Redirect(redirect, optionsAction);
         }
 
-        IVia IVia.Reset()
+        IVia IVia.Reset(bool includePersistent)
         {
-            return Reset();
+            return Reset(includePersistent);
         }
 
         IVia IVia.Strict(bool? isStrict)
@@ -133,9 +133,9 @@ namespace DivertR
             return Strict(isStrict);
         }
 
-        public IVia<TTarget> Reset()
+        public IVia<TTarget> Reset(bool includePersistent = false)
         {
-            RedirectRepository.Reset();
+            RedirectRepository.Reset(includePersistent);
 
             return this;
         }

--- a/src/DivertR/ViaSet.cs
+++ b/src/DivertR/ViaSet.cs
@@ -4,10 +4,10 @@ using System.Reflection;
 
 namespace DivertR
 {
+    /// <inheritdoc />
     public class ViaSet : IViaSet
     {
-        private readonly ConcurrentDictionary<string, ConcurrentDictionary<Type, IVia>> _viaGroups =
-            new ConcurrentDictionary<string, ConcurrentDictionary<Type, IVia>>();
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<Type, IVia>> _viaGroups = new();
         
         public ViaSet(DiverterSettings? settings = null)
         {
@@ -45,31 +45,24 @@ namespace DivertR
             return viaGroup.GetOrAdd(viaId.Type, CreateVia);
         }
 
-        public IVia? Reset(ViaId viaId)
-        {
-            var viaGroup = GetViaGroup(viaId.Name);
-            
-            return viaGroup.TryGetValue(viaId.Type, out var via) ? via.Reset() : null;
-        }
-
-        public IViaSet Reset(string? name = null)
+        public IViaSet Reset(string? name = null, bool includePersistent = false)
         {
             var viaGroup = GetViaGroup(name);
             foreach (var via in viaGroup.Values)
             {
-                via.Reset();
+                via.Reset(includePersistent);
             }
 
             return this;
         }
 
-        public IViaSet ResetAll()
+        public IViaSet ResetAll(bool includePersistent = false)
         {
             foreach (var viaGroup in _viaGroups.Values)
             {
                 foreach (var via in viaGroup.Values)
                 {
-                    via.Reset();
+                    via.Reset(includePersistent);
                 }
             }
 

--- a/test/DivertR.UnitTests/DiverterTests.cs
+++ b/test/DivertR.UnitTests/DiverterTests.cs
@@ -37,11 +37,47 @@ namespace DivertR.UnitTests
             var via = _diverter.Via<IFoo>();
             var subject = via.Proxy(original);
             
-            via.Retarget(new FooAlt(() => $"{via.Relay.Next} me"));
-            via.Retarget(new FooAlt(() => $"{via.Relay.Next} again"));
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"));
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"));
 
             // ACT
             _diverter.ResetAll();
+            
+            // ASSERT
+            subject.Name.ShouldBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirects_WhenResetAll_ShouldNotReset()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var via = _diverter.Via<IFoo>();
+            var subject = via.Proxy(original);
+            
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"), opt => opt.Persist());
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"), opt => opt.Persist());
+
+            // ACT
+            _diverter.ResetAll();
+            
+            // ASSERT
+            subject.Name.ShouldBe("hello foo me again");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirects_WhenResetAllIncludingPersistent_ShouldReset()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var via = _diverter.Via<IFoo>();
+            var subject = via.Proxy(original);
+            
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"), opt => opt.Persist());
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"), opt => opt.Persist());
+
+            // ACT
+            _diverter.ResetAll(includePersistent: true);
             
             // ASSERT
             subject.Name.ShouldBe(original.Name);
@@ -55,11 +91,47 @@ namespace DivertR.UnitTests
             var via = _diverter.Via<IFoo>();
             var subject = via.Proxy(original);
             
-            via.Retarget(new FooAlt(() => $"{via.Relay.Next} me"));
-            via.Retarget(new FooAlt(() => $"{via.Relay.Next} again"));
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"));
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"));
 
             // ACT
             _diverter.Reset();
+            
+            // ASSERT
+            subject.Name.ShouldBe(original.Name);
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirects_WhenResetGroup_ShouldNotReset()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var via = _diverter.Via<IFoo>();
+            var subject = via.Proxy(original);
+            
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"), opt => opt.Persist());
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"), opt => opt.Persist());
+
+            // ACT
+            _diverter.Reset();
+            
+            // ASSERT
+            subject.Name.ShouldBe("hello foo me again");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirects_WhenResetGroupIncludingPersistent_ShouldReset()
+        {
+            // ARRANGE
+            var original = new Foo("hello foo");
+            var via = _diverter.Via<IFoo>();
+            var subject = via.Proxy(original);
+            
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} me"), opt => opt.Persist());
+            via.Retarget(new FooAlt(() => $"{via.Relay.CallNext()} again"), opt => opt.Persist());
+
+            // ACT
+            _diverter.Reset(includePersistent: true);
             
             // ASSERT
             subject.Name.ShouldBe(original.Name);

--- a/test/DivertR.UnitTests/ViaTests.cs
+++ b/test/DivertR.UnitTests/ViaTests.cs
@@ -90,5 +90,140 @@ namespace DivertR.UnitTests
             // ASSERT
             result.ShouldBe("divert");
         }
+        
+        [Fact]
+        public void GivenPersistentRedirect_ShouldRedirect()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            // ACT
+            var name = proxy.Name;
+
+            // ASSERT
+            name.ShouldBe("foo changed");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirect_WhenReset_ShouldNotRemoveRedirect()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            // ACT
+            _via.Reset();
+
+            // ASSERT
+            proxy.Name.ShouldBe("foo changed");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirect_WhenResetIncludingPersistent_ShouldRemoveRedirect()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            // ACT
+            _via.Reset(includePersistent: true);
+
+            // ASSERT
+            proxy.Name.ShouldBe("foo");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirectFollowedByNormalRedirect_ShouldRedirectChain()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " again");
+            
+            // ACT
+            var name = proxy.Name;
+
+            // ASSERT
+            name.ShouldBe("foo changed again");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirectFollowedByNormalRedirect_WhenViaReset_ShouldKeepPersistentRedirect()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " again");
+            
+            // ACT
+            _via.Reset();
+
+            // ASSERT
+            proxy.Name.ShouldBe("foo changed");
+        }
+        
+        [Fact]
+        public void GivenPersistentRedirectFollowedByNormalRedirect_WhenViaResetIncludingPersistent_ShouldResetAll()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed", opt => opt.Persist());
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " again");
+            
+            // ACT
+            _via.Reset(includePersistent: true);
+
+            // ASSERT
+            proxy.Name.ShouldBe("foo");
+        }
+        
+        [Fact]
+        public void GivenNormalRedirectFollowedByPersistentRedirect_WhenViaReset_ShouldKeepPersistentRedirect()
+        {
+            // ARRANGE
+            var proxy = _via.Proxy(new Foo("foo"));
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " changed");
+            
+            _via
+                .To(x => x.Name)
+                .Redirect(call => call.CallNext() + " persistent", opt => opt.Persist());
+            
+            // ACT
+            _via.Reset();
+
+            // ASSERT
+            proxy.Name.ShouldBe("foo persistent");
+        }
     }
 }


### PR DESCRIPTION
This adds an option to "persist" the redirect when inserting. Persisted redirects are not removed when the Via is reset. This allows to configure an initial test system state that does not get cleared on reset and can be returned to between tests.

The reset methods have also been updated to include and optional Boolean flag to include persisted redirects in the reset.