### PR TITLE
Update Diverter to return existing Redirects from its RedirectSet

### DIFF
--- a/src/DivertR/Diverter.cs
+++ b/src/DivertR/Diverter.cs
@@ -89,11 +89,13 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IRedirect Redirect(RedirectId id)
+        public IRedirect Redirect(RedirectId redirectId)
         {
-            if (!_registeredRedirects.TryGetValue(id, out var redirect))
+            var redirect = RedirectSet.GetRedirect(redirectId);
+            
+            if (redirect == null)
             {
-                throw new DiverterException($"Redirect not registered for {id}");
+                throw new DiverterException($"Redirect not registered for {redirectId}");
             }
             
             return redirect;

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -56,10 +56,10 @@ namespace DivertR
         /// <summary>
         /// Retrieve a registered <see cref="IRedirect" /> instance.
         /// </summary>
-        /// <param name="id">The <see cref="IRedirect" /> id.</param>
+        /// <param name="redirectId">The <see cref="IRedirect" /> id.</param>
         /// <returns>The registered <see cref="IRedirect" /> instance.</returns>
         /// <exception cref="DiverterException">If the <see cref="IRedirect" /> has not been registered.</exception>
-        IRedirect Redirect(RedirectId id);
+        IRedirect Redirect(RedirectId redirectId);
         
         /// <summary>
         /// Retrieve a registered <see cref="IRedirect" /> instance.

--- a/src/DivertR/IRedirectSet.cs
+++ b/src/DivertR/IRedirectSet.cs
@@ -23,6 +23,36 @@ namespace DivertR
         IRedirect Redirect(Type targetType, string? name = null);
 
         /// <summary>
+        /// Get or create a Redirect in this set by id.
+        /// </summary>
+        /// <param name="redirectId">The Redirect id.</param>
+        /// <returns>The existing or created Redirect.</returns>
+        IRedirect Redirect(RedirectId redirectId);
+        
+        /// <summary>
+        /// Get the Redirect in this set for a given target type.
+        /// </summary>
+        /// <param name="name">Optional Redirect group name.</param>
+        /// <typeparam name="TTarget">The Redirect target type.</typeparam>
+        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
+        IRedirect<TTarget>? GetRedirect<TTarget>(string? name = null) where TTarget : class?;
+        
+        /// <summary>
+        /// Get a Redirect in this set for a given target type.
+        /// </summary>
+        /// <param name="targetType">The Redirect target type.</param>
+        /// <param name="name">Optional Redirect group name.</param>
+        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
+        IRedirect? GetRedirect(Type targetType, string? name = null);
+
+        /// <summary>
+        /// Get a Redirect in this set by id.
+        /// </summary>
+        /// <param name="redirectId">The Redirect id.</param>
+        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
+        IRedirect? GetRedirect(RedirectId redirectId);
+
+        /// <summary>
         /// Reset the specified group of <see cref="IRedirect" />s in this set.
         /// </summary>
         /// <param name="name">The Redirect group name.</param>

--- a/src/DivertR/RedirectSet.cs
+++ b/src/DivertR/RedirectSet.cs
@@ -31,7 +31,13 @@ namespace DivertR
         public IRedirect Redirect(Type targetType, string? name = null)
         {
             var redirectId = RedirectId.From(targetType, name);
-            
+
+            return Redirect(redirectId);
+        }
+        
+        /// <inheritdoc />
+        public IRedirect Redirect(RedirectId redirectId)
+        {
             IRedirect CreateRedirect(Type type)
             {
                 const BindingFlags ActivatorFlags = BindingFlags.NonPublic | BindingFlags.Instance;
@@ -47,7 +53,33 @@ namespace DivertR
             
             return redirectGroup.GetOrAdd(redirectId.Type, CreateRedirect);
         }
+
+        /// <inheritdoc />
+        public IRedirect<TTarget>? GetRedirect<TTarget>(string? name = null) where TTarget : class?
+        {
+            var redirectId = RedirectId.From<TTarget>(name);
+            var redirect = GetRedirect(redirectId);
+
+            return (IRedirect<TTarget>?) redirect;
+        }
         
+        /// <inheritdoc />
+        public IRedirect? GetRedirect(Type targetType, string? name = null)
+        {
+            var redirectId = RedirectId.From(targetType, name);
+
+            return GetRedirect(redirectId);
+        }
+        
+        /// <inheritdoc />
+        public IRedirect? GetRedirect(RedirectId redirectId)
+        {
+            var redirectGroup = GetRedirectGroup(redirectId.Name);
+            redirectGroup.TryGetValue(redirectId.Type, out var redirect);
+           
+            return redirect;
+        }
+
         /// <inheritdoc />
         public IRedirectSet Reset(string? name = null, bool includePersistent = false)
         {

--- a/test/DivertR.UnitTests/DiverterTests.cs
+++ b/test/DivertR.UnitTests/DiverterTests.cs
@@ -213,5 +213,33 @@ namespace DivertR.UnitTests
             foo.ShouldNotBeNull();
             list.ShouldNotBeNull();
         }
+        
+        [Fact]
+        public void GivenDiverter_WhenGetUnregisteredRedirect_ThrowsDiverterException()
+        {
+            // ARRANGE
+
+            // ACT
+            var testAction = () => _diverter.Redirect<INumber>();
+            
+            // ASSERT
+            testAction.ShouldThrow<DiverterException>();
+        }
+        
+        [Fact]
+        public void GivenDiverterWithNonRegisteredViaRedirect_WhenGetUnregisteredRedirect_ThenReturnsRedirect()
+        {
+            // ARRANGE
+            _diverter
+                .Redirect<IFoo>()
+                .To(x => x.EchoGeneric(Is<INumber>.Any))
+                .ViaRedirect();
+
+            // ACT
+            var numberRedirect = _diverter.Redirect<INumber>();
+            
+            // ASSERT
+            numberRedirect.ShouldNotBeNull();
+        }
     }
 }

--- a/test/DivertR.UnitTests/RedirectSetTests.cs
+++ b/test/DivertR.UnitTests/RedirectSetTests.cs
@@ -1,0 +1,190 @@
+﻿using DivertR.UnitTests.Model;
+using Shouldly;
+using Xunit;
+
+namespace DivertR.UnitTests;
+
+public class RedirectSetTests
+{
+    private readonly IRedirectSet _redirectSet;
+
+    public RedirectSetTests()
+    {
+        _redirectSet = new RedirectSet();
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddRedirect_ThenReturnsExistingFooRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        
+        // ACT
+        var testRedirect = _redirectSet.Redirect<IFoo>();
+        
+        // ASSERT
+        testRedirect.ShouldNotBeNull();
+        testRedirect.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetOrAddSameNamedRedirect_ThenReturnsExistingFooRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+        
+        // ACT
+        var testRedirect = _redirectSet.Redirect<IFoo>("test");
+        
+        // ASSERT
+        testRedirect.ShouldNotBeNull();
+        testRedirect.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddNamedRedirect_ThenCreatesNewFooRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        
+        // ACT
+        var testRedirect = _redirectSet.Redirect<IFoo>("test");
+        
+        // ASSERT
+        testRedirect.ShouldNotBeNull();
+        testRedirect.ShouldNotBe(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddRedirectByType_ThenReturnsExistingFooRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        
+        // ACT
+        var testRedirect = _redirectSet.Redirect(typeof(IFoo));
+        
+        // ASSERT
+        testRedirect.ShouldNotBeNull();
+        testRedirect.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenEmptyRedirectSet_WhenGetRedirect_ThenReturnsNull()
+    {
+        // ARRANGE
+
+        // ACT
+        var result = _redirectSet.GetRedirect<IFoo>();
+        
+        // ASSERT
+        result.ShouldBeNull();
+    }
+    
+    [Fact]
+    public void GivenEmptyRedirectSet_WhenGetRedirectByType_ThenReturnsNull()
+    {
+        // ARRANGE
+
+        // ACT
+        var result = _redirectSet.GetRedirect(typeof(IFoo));
+        
+        // ASSERT
+        result.ShouldBeNull();
+    }
+    
+    [Fact]
+    public void GivenEmptyRedirectSet_WhenGetRedirectById_ThenReturnsNull()
+    {
+        // ARRANGE
+
+        // ACT
+        var result = _redirectSet.GetRedirect(RedirectId.From<IFoo>());
+        
+        // ASSERT
+        result.ShouldBeNull();
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetRedirect_ThenReturnsNull()
+    {
+        // ARRANGE
+        _redirectSet.Redirect<IFoo>("test");
+
+        // ACT
+        var result = _redirectSet.GetRedirect<IFoo>();
+        
+        // ASSERT
+        result.ShouldBeNull();
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirect_ThenReturnsRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+
+        // ACT
+        var result = _redirectSet.GetRedirect<IFoo>();
+        
+        // ASSERT
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetNamedRedirect_ThenReturnsRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+
+        // ACT
+        var result = _redirectSet.GetRedirect<IFoo>("test");
+        
+        // ASSERT
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirectByType_ThenReturnsRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+
+        // ACT
+        var result = _redirectSet.GetRedirect(typeof(IFoo));
+        
+        // ASSERT
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirectById_ThenReturnsRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>();
+
+        // ACT
+        var result = _redirectSet.GetRedirect(RedirectId.From<IFoo>());
+        
+        // ASSERT
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(fooRedirect);
+    }
+    
+    [Fact]
+    public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetNamedRedirectByType_ThenReturnsRedirect()
+    {
+        // ARRANGE
+        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+
+        // ACT
+        var result = _redirectSet.GetRedirect(typeof(IFoo), "test");
+        
+        // ASSERT
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(fooRedirect);
+    }
+}

--- a/test/DivertR.WebAppTests/WebAppFixture.cs
+++ b/test/DivertR.WebAppTests/WebAppFixture.cs
@@ -61,7 +61,7 @@ namespace DivertR.WebAppTests
         {
             var logger = output.BuildLogger(LogLevel.Information);
             
-            _diverter.RedirectSet
+            _diverter
                 .Redirect<ILogger>()
                 .Retarget(logger);
         }


### PR DESCRIPTION
Previously a `Diverter` instance only allowed retrieval of `Redirect`s. If an attempt was made to retrieve an unregistered `Redirect` a `DiverterException` was thrown.

This update is to extend a `Diverter` instance to also be able to retrieve any existing `Redirect` from its `RedirectSet`. So, for example, if a `Redirect` has been inserted into the `RedirectSet` from a `ViaRedirect` this allows it to be retrieved directly from the `Diverter` instance.