### PR TITLE
Remove all occurrence of delegates with second args param

### DIFF
--- a/src/DivertR/IActionRedirectUpdater.cs
+++ b/src/DivertR/IActionRedirectUpdater.cs
@@ -12,7 +12,6 @@ namespace DivertR
         
         IActionRedirectUpdater<TTarget> Via(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
         IActionRedirectUpdater<TTarget> Via(Action<IActionRedirectCall<TTarget>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        IActionRedirectUpdater<TTarget> Via(Action<IActionRedirectCall<TTarget>, CallArguments> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
 
         IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
@@ -20,9 +19,6 @@ namespace DivertR
         IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
-        IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-            where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        
         IActionRedirectUpdater<TTarget> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
         
         IActionRedirectUpdater<TTarget, TArgs> Retarget<TArgs>(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
@@ -45,7 +41,6 @@ namespace DivertR
         
         new IActionRedirectUpdater<TTarget, TArgs> Via(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
         IActionRedirectUpdater<TTarget, TArgs> Via(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        IActionRedirectUpdater<TTarget, TArgs> Via(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
 
         new IActionRedirectUpdater<TTarget, TArgs> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
         

--- a/src/DivertR/IFuncRedirectUpdater.cs
+++ b/src/DivertR/IFuncRedirectUpdater.cs
@@ -13,7 +13,6 @@ namespace DivertR
         IFuncRedirectUpdater<TTarget, TReturn> Via(TReturn instance, Action<IViaOptionsBuilder>? optionsAction = null);
         IFuncRedirectUpdater<TTarget, TReturn> Via(Func<TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
         IFuncRedirectUpdater<TTarget, TReturn> Via(Func<IFuncRedirectCall<TTarget, TReturn>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        IFuncRedirectUpdater<TTarget, TReturn> Via(Func<IFuncRedirectCall<TTarget, TReturn>, CallArguments, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
 
         IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(TReturn instance, Action<IViaOptionsBuilder>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
@@ -22,9 +21,6 @@ namespace DivertR
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
         IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-            where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        
-        IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
 
         IFuncRedirectUpdater<TTarget, TReturn> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
@@ -51,8 +47,7 @@ namespace DivertR
         new IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
 
         IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        
+
         new IFuncRedirectUpdater<TTarget, TReturn, TArgs> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
        
         new IFuncCallStream<TTarget, TReturn, TArgs> Record(Action<IViaOptionsBuilder>? optionsAction = null);

--- a/src/DivertR/IRedirectUpdater.cs
+++ b/src/DivertR/IRedirectUpdater.cs
@@ -7,12 +7,10 @@ namespace DivertR
     {
         IRedirect<TTarget> Redirect { get; }
         IViaBuilder<TTarget> ViaBuilder { get; }
-        
         IRedirectUpdater<TTarget> Filter(ICallConstraint<TTarget> callConstraint);
         IRedirectUpdater<TTarget> Via(object? instance, Action<IViaOptionsBuilder>? optionsAction = null);
         IRedirectUpdater<TTarget> Via(Func<object?> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
         IRedirectUpdater<TTarget> Via(Func<IRedirectCall<TTarget>, object?> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
-        IRedirectUpdater<TTarget> Via(Func<IRedirectCall<TTarget>, CallArguments, object?> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
         IRedirectUpdater<TTarget> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
         IRecordStream<TTarget> Record(Action<IViaOptionsBuilder>? optionsAction = null);
     }

--- a/src/DivertR/Internal/ActionRedirectUpdater.cs
+++ b/src/DivertR/Internal/ActionRedirectUpdater.cs
@@ -37,25 +37,12 @@ namespace DivertR.Internal
             return this;
         }
 
-        public IActionRedirectUpdater<TTarget> Via(Action<IActionRedirectCall<TTarget>, CallArguments> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            var via = ViaBuilder.Build(viaDelegate);
-            InsertVia(via, optionsAction);
-            
-            return this;
-        }
-
         public IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Via(viaDelegate, optionsAction);
         }
 
         public IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Via(viaDelegate, optionsAction);
-        }
-
-        public IActionRedirectUpdater<TTarget, TArgs> Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Via(viaDelegate, optionsAction);
         }
@@ -113,14 +100,6 @@ namespace DivertR.Internal
         }
 
         public IActionRedirectUpdater<TTarget, TArgs> Via(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            var via = ViaBuilder.Build(viaDelegate);
-            InsertVia(via, optionsAction);
-            
-            return this;
-        }
-
-        public IActionRedirectUpdater<TTarget, TArgs> Via(Action<IActionRedirectCall<TTarget, TArgs>, TArgs> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             var via = ViaBuilder.Build(viaDelegate);
             InsertVia(via, optionsAction);

--- a/src/DivertR/Internal/FuncRedirectUpdater.cs
+++ b/src/DivertR/Internal/FuncRedirectUpdater.cs
@@ -42,14 +42,6 @@ namespace DivertR.Internal
             return this;
         }
 
-        public IFuncRedirectUpdater<TTarget, TReturn> Via(Func<IFuncRedirectCall<TTarget, TReturn>, CallArguments, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            var via = ViaBuilder.Build(viaDelegate);
-            InsertVia(via, optionsAction);
-
-            return this;
-        }
-
         public IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(TReturn instance, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Via(instance, optionsAction);
@@ -62,11 +54,6 @@ namespace DivertR.Internal
 
         public IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
             where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Via(viaDelegate, optionsAction);
-        }
-
-        public IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Via(viaDelegate, optionsAction);
         }
@@ -130,22 +117,7 @@ namespace DivertR.Internal
             return this;
         }
 
-        public new IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<IFuncRedirectCall<TTarget, TReturn>, CallArguments, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            base.Via(viaDelegate, optionsAction);
-
-            return this;
-        }
-
         public IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            var via = ViaBuilder.Build(viaDelegate);
-            InsertVia(via, optionsAction);
-
-            return this;
-        }
-
-        public IFuncRedirectUpdater<TTarget, TReturn, TArgs> Via(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TArgs, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             var via = ViaBuilder.Build(viaDelegate);
             InsertVia(via, optionsAction);

--- a/src/DivertR/Internal/RedirectUpdater.cs
+++ b/src/DivertR/Internal/RedirectUpdater.cs
@@ -45,14 +45,6 @@ namespace DivertR.Internal
             return this;
         }
 
-        public IRedirectUpdater<TTarget> Via(Func<IRedirectCall<TTarget>, CallArguments, object?> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
-        {
-            var via = ViaBuilder.Build(viaDelegate);
-            InsertVia(via, optionsAction);
-
-            return this;
-        }
-
         public IRedirectUpdater<TTarget> Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             ICallHandler<TTarget> callHandler = new TargetCallHandler<TTarget>(target, Redirect.RedirectSet.Settings.CallInvoker);

--- a/src/DivertR/Internal/Relay.cs
+++ b/src/DivertR/Internal/Relay.cs
@@ -168,7 +168,7 @@ namespace DivertR.Internal
             {
                 if (redirectPlan.IsStrictMode)
                 {
-                    throw new StrictNotSatisfiedException("Strict mode is enabled and the call did not match any Redirects");
+                    throw new StrictNotSatisfiedException("Strict mode is enabled and the call did not match any Vias");
                 }
                 
                 return CallRoot(callInfo);
@@ -213,7 +213,7 @@ namespace DivertR.Internal
             if (relayIndexStack == null || relayIndexStack.IsEmpty)
             {
                 // The AsyncLocal value has not been initialised in the current context, therefore the caller in not within a call on this Relay.
-                throw new DiverterException("Access to this member is only valid within the context of a Via call");
+                throw new DiverterException("Access to this member is only valid within the context of a Redirect call");
             }
 
             return relayIndexStack;
@@ -224,7 +224,7 @@ namespace DivertR.Internal
         {
             if (!relayIndex.StrictSatisfied)
             {
-                throw new StrictNotSatisfiedException("Strict mode is enabled and the call did not match any Redirects");
+                throw new StrictNotSatisfiedException("Strict mode is enabled and the call did not match any Vias");
             }
         }
 

--- a/src/DivertR/Record/IActionCallStream.cs
+++ b/src/DivertR/Record/IActionCallStream.cs
@@ -8,17 +8,10 @@ namespace DivertR.Record
         where TTarget : class?
     {
         IActionCallStream<TTarget, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        
-        ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget>, CallArguments, TMap> mapper);
-        
-        IVerifySnapshot<IRecordedCall<TTarget>> Verify(Action<IRecordedCall<TTarget>, CallArguments> visitor);
-        Task<IVerifySnapshot<IRecordedCall<TTarget>>> Verify(Func<IRecordedCall<TTarget>, CallArguments, Task> visitor);
-        
+
         IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>(Action<IRecordedCall<TTarget, TArgs>> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
     
     public interface IActionCallStream<TTarget, TArgs> : ICallStream<IRecordedCall<TTarget, TArgs>>
@@ -26,15 +19,8 @@ namespace DivertR.Record
     {
         IActionCallStream<TTarget, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
-        ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget, TArgs>, TArgs, TMap> mapper);
-
-        IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor);
-        Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor);
-        
         IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>(Action<IRecordedCall<TTarget, TNewArgs>> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>(Action<IRecordedCall<TTarget, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
 }

--- a/src/DivertR/Record/IFuncCallStream.cs
+++ b/src/DivertR/Record/IFuncCallStream.cs
@@ -9,16 +9,10 @@ namespace DivertR.Record
     {
         IFuncCallStream<TTarget, TReturn, TArgs> Args<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
-        ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, TMap> mapper);
-        
-        IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn>> Verify(Action<IFuncRecordedCall<TTarget, TReturn>, CallArguments> visitor);
         Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn>>> Verify(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, Task> visitor);
-        
         IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
     
     public interface IFuncCallStream<TTarget, TReturn, TArgs> : ICallStream<IFuncRecordedCall<TTarget, TReturn, TArgs>>
@@ -26,23 +20,12 @@ namespace DivertR.Record
     {
         IFuncCallStream<TTarget, TReturn, TNewArgs> Args<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         
-        ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, TMap> mapper);
-
-        IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor);
-        Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor);
-        
         IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>() where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
         Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
-        Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
     }
     
     public interface IFuncCallStream<TReturn> : ICallStream<IFuncRecordedCall<TReturn>>
     {
-        ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TReturn>, CallArguments, TMap> mapper);
-        
-        IVerifySnapshot<IFuncRecordedCall<TReturn>> Verify(Action<IFuncRecordedCall<TReturn>, CallArguments> visitor);
-        Task<IVerifySnapshot<IFuncRecordedCall<TReturn>>> Verify(Func<IFuncRecordedCall<TReturn>, CallArguments, Task> visitor);
     }
 }

--- a/src/DivertR/Record/Internal/ActionCallStream.cs
+++ b/src/DivertR/Record/Internal/ActionCallStream.cs
@@ -22,21 +22,6 @@ namespace DivertR.Record.Internal
             return Args<TArgs>(Calls, _callValidator);
         }
 
-        public ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget>, CallArguments, TMap> mapper)
-        {
-            return new CallStream<TMap>(Calls.Select(call => mapper.Invoke(call, call.Args)));
-        }
-
-        public IVerifySnapshot<IRecordedCall<TTarget>> Verify(Action<IRecordedCall<TTarget>, CallArguments> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        public Task<IVerifySnapshot<IRecordedCall<TTarget>>> Verify(Func<IRecordedCall<TTarget>, CallArguments, Task> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
         public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>() where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Verify();
@@ -47,21 +32,11 @@ namespace DivertR.Record.Internal
             return Args<TArgs>().Verify(visitor);
         }
 
-        public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify<TArgs>(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Verify(visitor);
-        }
-
         public Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Verify(visitor);
         }
 
-        public Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify<TArgs>(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Verify(visitor);
-        }
-        
         internal static IActionCallStream<TTarget, TArgs> Args<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             var valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
@@ -93,17 +68,7 @@ namespace DivertR.Record.Internal
             return ActionCallStream<TTarget>.Args<TNewArgs>(Calls, _callValidator);
         }
 
-        public ICallStream<TMap> Map<TMap>(Func<IRecordedCall<TTarget, TArgs>, TArgs, TMap> mapper)
-        {
-            return new CallStream<TMap>(Calls.Select(call => mapper.Invoke(call, call.Args)));
-        }
-
         public IVerifySnapshot<IRecordedCall<TTarget, TArgs>> Verify(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        public Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> Verify(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor)
         {
             return base.Verify(call => visitor.Invoke(call, call.Args));
         }
@@ -128,16 +93,6 @@ namespace DivertR.Record.Internal
             return Args<TNewArgs>().Verify(visitor);
         }
 
-        public IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>> Verify<TNewArgs>(Action<IRecordedCall<TTarget, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            if (visitor is Action<IRecordedCall<TTarget, TArgs>, TArgs> v)
-            {
-                return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) VerifyInternal(v);
-            }
-            
-            return Args<TNewArgs>().Verify(visitor);
-        }
-
         public async Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             if (visitor is Func<IRecordedCall<TTarget, TArgs>, Task> v)
@@ -146,26 +101,6 @@ namespace DivertR.Record.Internal
             }
             
             return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
-        }
-
-        public async Task<IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>> Verify<TNewArgs>(Func<IRecordedCall<TTarget, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            if (visitor is Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> v)
-            {
-                return (IVerifySnapshot<IRecordedCall<TTarget, TNewArgs>>) await VerifyInternal(v).ConfigureAwait(false);
-            }
-            
-            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
-        }
-        
-        private IVerifySnapshot<IRecordedCall<TTarget, TArgs>> VerifyInternal(Action<IRecordedCall<TTarget, TArgs>, TArgs> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        private Task<IVerifySnapshot<IRecordedCall<TTarget, TArgs>>> VerifyInternal(Func<IRecordedCall<TTarget, TArgs>, TArgs, Task> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
         }
     }
 }

--- a/src/DivertR/Record/Internal/FuncCallStream.cs
+++ b/src/DivertR/Record/Internal/FuncCallStream.cs
@@ -21,16 +21,6 @@ namespace DivertR.Record.Internal
         {
             return Args<TArgs>(Calls, _callValidator);
         }
-        
-        public ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, TMap> mapper)
-        {
-            return new CallStream<TMap>(Calls.Select(call => mapper.Invoke(call, call.Args)));
-        }
-
-        public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn>> Verify(Action<IFuncRecordedCall<TTarget, TReturn>, CallArguments> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
 
         public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn>>> Verify(Func<IFuncRecordedCall<TTarget, TReturn>, CallArguments, Task> visitor)
         {
@@ -47,21 +37,11 @@ namespace DivertR.Record.Internal
             return Args<TArgs>().Verify(visitor);
         }
 
-        public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify<TArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Verify(visitor);
-        }
-
         public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             return Args<TArgs>().Verify(visitor);
         }
 
-        public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify<TArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            return Args<TArgs>().Verify(visitor);
-        }
-        
         internal static IFuncCallStream<TTarget, TReturn, TArgs> Args<TArgs>(IEnumerable<IRecordedCall<TTarget>> calls, ICallValidator callValidator) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             var valueTupleMapper = ValueTupleMapperFactory.Create<TArgs>();
@@ -93,17 +73,7 @@ namespace DivertR.Record.Internal
             return FuncCallStream<TTarget, TReturn>.Args<TNewArgs>(Calls, _callValidator);
         }
 
-        public ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, TMap> mapper)
-        {
-            return new CallStream<TMap>(Calls.Select(call => mapper.Invoke(call, call.Args)));
-        }
-
         public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> Verify(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        public Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> Verify(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor)
         {
             return base.Verify(call => visitor.Invoke(call, call.Args));
         }
@@ -128,16 +98,6 @@ namespace DivertR.Record.Internal
             return Args<TNewArgs>().Verify(visitor);
         }
 
-        public IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>> Verify<TNewArgs>(Action<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            if (visitor is Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> v)
-            {
-                return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) VerifyInternal(v);
-            }
-            
-            return Args<TNewArgs>().Verify(visitor);
-        }
-
         public async Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
         {
             if (visitor is Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, Task> v)
@@ -147,47 +107,12 @@ namespace DivertR.Record.Internal
             
             return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
         }
-
-        public async Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>> Verify<TNewArgs>(Func<IFuncRecordedCall<TTarget, TReturn, TNewArgs>, TNewArgs, Task> visitor) where TNewArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
-        {
-            if (visitor is Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> v)
-            {
-                return (IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TNewArgs>>) await VerifyInternal(v).ConfigureAwait(false);
-            }
-            
-            return await Args<TNewArgs>().Verify(visitor).ConfigureAwait(false);
-        }
-        
-        private IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>> VerifyInternal(Action<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        private Task<IVerifySnapshot<IFuncRecordedCall<TTarget, TReturn, TArgs>>> VerifyInternal(Func<IFuncRecordedCall<TTarget, TReturn, TArgs>, TArgs, Task> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
     }
 
     internal class FuncCallStream<TReturn> : CallStream<IFuncRecordedCall<TReturn>>, IFuncCallStream<TReturn>
     {
         public FuncCallStream(IEnumerable<IFuncRecordedCall<TReturn>> calls) : base(calls)
         {
-        }
-
-        public ICallStream<TMap> Map<TMap>(Func<IFuncRecordedCall<TReturn>, CallArguments, TMap> mapper)
-        {
-            return new CallStream<TMap>(Calls.Select(call => mapper.Invoke(call, call.Args)));
-        }
-
-        public IVerifySnapshot<IFuncRecordedCall<TReturn>> Verify(Action<IFuncRecordedCall<TReturn>, CallArguments> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
-        }
-
-        public Task<IVerifySnapshot<IFuncRecordedCall<TReturn>>> Verify(Func<IFuncRecordedCall<TReturn>, CallArguments, Task> visitor)
-        {
-            return base.Verify(call => visitor.Invoke(call, call.Args));
         }
     }
 }

--- a/test/DivertR.UnitTests/ByRefDelegateTests.cs
+++ b/test/DivertR.UnitTests/ByRefDelegateTests.cs
@@ -35,10 +35,10 @@ namespace DivertR.UnitTests
             // ARRANGE
             _redirect
                 .To(x => x.RefNumber(ref IsRef<int>.Match(m => m == 3).Value))
-                .Via<(Ref<int> i, __)>((call, args) =>
+                .Via<(Ref<int> i, __)>(call =>
                 {
-                    var refIn = call.Next.RefNumber(ref args.i.Value);
-                    args.i.Value += 10;
+                    var refIn = call.Next.RefNumber(ref call.Args.i.Value);
+                    call.Args.i.Value += 10;
 
                     return refIn;
                 });
@@ -76,10 +76,10 @@ namespace DivertR.UnitTests
             // ARRANGE
             _redirect
                 .To(x => x.OutNumber(Is<int>.Any, out IsRef<int>.Any))
-                .Via<(int i, Ref<int> o)>((call, args) =>
+                .Via<(int i, Ref<int> o)>(call =>
                 {
-                    call.Next.OutNumber(args.i, out args.o.Value);
-                    args.o.Value += 10;
+                    call.Next.OutNumber(call.Args.i, out call.Args.o.Value);
+                    call.Args.o.Value += 10;
                 });
             
             var redirectProxy = _redirect.Proxy(new Number());
@@ -113,10 +113,10 @@ namespace DivertR.UnitTests
             // ARRANGE
             var recordStream = _redirect
                 .To(x => x.OutNumber(Is<int>.Any, out IsRef<int>.Any))
-                .Via<(int i, Ref<int> o)>((call, args) =>
+                .Via<(int i, Ref<int> o)>(call =>
                 {
-                    call.Next.OutNumber(args.i, out args.o.Value);
-                    args.o.Value += 10;
+                    call.Next.OutNumber(call.Args.i, out call.Args.o.Value);
+                    call.Args.o.Value += 10;
                 })
                 .Record();
             

--- a/test/DivertR.UnitTests/MapTests.cs
+++ b/test/DivertR.UnitTests/MapTests.cs
@@ -154,7 +154,7 @@ namespace DivertR.UnitTests
                 .To(x => x.OutNumber(Is<int>.Any, out IsRef<int>.Any))
                 .Via<(int input, Ref<int> output)>(call => call.Relay.Next.OutNumber(call.Args.input, out call.Args.output.Value))
                 .Record()
-                .Map((_, args) => new { args.input, output = args.output.Value });
+                .Map(call => new { call.Args.input, output = call.Args.output.Value });
 
             // ACT
             var outputs = inputs.Select(i =>
@@ -181,9 +181,9 @@ namespace DivertR.UnitTests
                 .To(x => x.EchoAsync(Is<string>.Any))
                 .Via<(string input, __)>(call => Task.FromResult(call.Args.input + " diverted"))
                 .Record()
-                .Map(async (call, args) => new
+                .Map(async call => new
                 {
-                    Input = args.input,
+                    Input = call.Args.input,
                     Result = await call.Return!
                 });
 
@@ -272,9 +272,9 @@ namespace DivertR.UnitTests
                 .To(x => x.EchoAsync(Is<string>.Any))
                 .Via(call => Task.FromResult($"{call.Args[0]} diverted"))
                 .Record()
-                .Map((call, args) => new
+                .Map(call => new
                 {
-                    Input = (string) args[0],
+                    Input = (string) call.Args[0],
                     Result = call.Return
                 });
 
@@ -305,9 +305,9 @@ namespace DivertR.UnitTests
             
             var calls = _redirect
                 .To(x => x.SetName(Is<string>.Any))
-                .Via<(string input, __)>((call, args) =>
+                .Via<(string input, __)>(call =>
                 {
-                    call.Next.SetName($"{args.input} diverted");
+                    call.Next.SetName($"{call.Args.input} diverted");
                 })
                 .Record();
 
@@ -328,9 +328,9 @@ namespace DivertR.UnitTests
                 map.Result.ShouldBeNull();
             });
             
-            calls.Map((call, args) => new
+            calls.Map(call => new
             {
-                Input = args.input,
+                Input = call.Args.input,
                 Result = call.Return
             }).Verify(map =>
             {
@@ -347,9 +347,9 @@ namespace DivertR.UnitTests
             
             var calls = _redirect
                 .To(x => x.SetName(Is<string>.Any))
-                .Via((call, args) =>
+                .Via(call =>
                 {
-                    call.Next.SetName($"{args[0]} diverted");
+                    call.Next.SetName($"{call.Args[0]} diverted");
                 })
                 .Record();
 
@@ -366,9 +366,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             });
             
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args[0].ShouldBe($"test {input}");
+                call.Args[0].ShouldBe($"test {input}");
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
@@ -382,9 +382,9 @@ namespace DivertR.UnitTests
                 map.Result.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.Map((call, args) => new
+            calls.Map(call => new
             {
-                Input = (string) args[0],
+                Input = (string) call.Args[0],
                 Result = call.Return
             }).Verify(map =>
             {

--- a/test/DivertR.UnitTests/RecordStreamTests.cs
+++ b/test/DivertR.UnitTests/RecordStreamTests.cs
@@ -48,9 +48,9 @@ namespace DivertR.UnitTests
             echoCalls.Select(call => call.Return).ShouldBe(outputs);
 
             var i = 0;
-            echoCalls.Verify((_, args) =>
+            echoCalls.Verify(call =>
             {
-                args.input.ShouldBe(inputs[i++]);
+                call.Args.input.ShouldBe(inputs[i++]);
             }).Count().ShouldBe(inputs.Count);
         }
         
@@ -109,9 +109,9 @@ namespace DivertR.UnitTests
             caughtException.ShouldNotBeNull();
             _recordStream
                 .To(x => x.Echo("test"))
-                .Verify<(string input, __)>((call, args) =>
+                .Verify<(string input, __)>(call =>
                 {
-                    args.input.ShouldBe("test");
+                    call.Args.input.ShouldBe("test");
                     call.Exception.ShouldBeSameAs(caughtException);
                 }).Count.ShouldBe(1);
         }
@@ -332,9 +332,9 @@ namespace DivertR.UnitTests
                 .ShouldBe(inputs);
 
             var i = 0;
-            recordedCalls.Verify((call, args) =>
+            recordedCalls.Verify(call =>
             {
-                args.name.ShouldBe(inputs[i++]);
+                call.Args.name.ShouldBe(inputs[i++]);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(inputs.Count);
         }
@@ -391,7 +391,7 @@ namespace DivertR.UnitTests
             var mappedCalls = _recordStream
                 .To(x => x.Echo(Is<string>.Any))
                 .Args<(string input, __)>()
-                .Map((call, args) => new { Input = args.input, Result = call.Return });
+                .Map(call => new { Input = call.Args.input, Result = call.Return });
 
             var fooProxy = _redirect.Proxy();
 
@@ -422,7 +422,7 @@ namespace DivertR.UnitTests
             var mappedCalls = _recordStream
                 .To(x => x.EchoAsync(Is<string>.Any))
                 .Args<(string input, __)>()
-                .Map((call, args) => new { Input = args.input, Result = call.Return });
+                .Map(call => new { Input = call.Args.input, Result = call.Return });
 
             var fooProxy = _redirect.Proxy();
 

--- a/test/DivertR.UnitTests/RecordViaTests.cs
+++ b/test/DivertR.UnitTests/RecordViaTests.cs
@@ -98,9 +98,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.Verify<(string input, __)>((call, args) =>
+            calls.Verify<(string input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
@@ -139,9 +139,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.Verify<(string input, __)>((call, args) =>
+            calls.Verify<(string input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
@@ -151,9 +151,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
-            calls.Verify<(object input, __)>((call, args) =>
+            calls.Verify<(object input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBe(result);
             }).Count.ShouldBe(1);
             
@@ -199,9 +199,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
-            (await calls.Verify(async (call, args) =>
+            (await calls.Verify(async call =>
             {
-                (await (Task<string>) args[0]).ShouldBe(input);
+                (await (Task<string>) call.Args[0]).ShouldBe(input);
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
@@ -211,9 +211,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
-            (await calls.Verify<(Task<string> input, __)>(async (call, args) =>
+            (await calls.Verify<(Task<string> input, __)>(async call =>
             {
-                (await args.input).ShouldBe(input);
+                (await call.Args.input).ShouldBe(input);
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
         }
@@ -243,10 +243,10 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
-            (await calls.Verify(async (call, args) =>
+            (await calls.Verify(async call =>
             {
-                (await args.input1).ShouldBe(input1);
-                (await args.input2).ShouldBe(input2);
+                (await call.Args.input1).ShouldBe(input1);
+                (await call.Args.input2).ShouldBe(input2);
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
@@ -257,10 +257,10 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
-            (await calls.Verify<(Task<string> i1, Task<int> i2)>(async (call, args) =>
+            (await calls.Verify<(Task<string> i1, Task<int> i2)>(async call =>
             {
-                (await args.i1).ShouldBe(input1);
-                (await args.i2).ShouldBe(input2);
+                (await call.Args.i1).ShouldBe(input1);
+                (await call.Args.i2).ShouldBe(input2);
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
@@ -270,9 +270,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
             
-            (await calls.Verify<(Task<string> i1, __)>(async (call, args) =>
+            (await calls.Verify<(Task<string> i1, __)>(async call =>
             {
-                (await args.i1).ShouldBe(input1);
+                (await call.Args.i1).ShouldBe(input1);
                 call.Return.ShouldBe(result);
             })).Count.ShouldBe(1);
         }
@@ -299,9 +299,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             })).Count.ShouldBe(1);
             
-            (await calls.Verify(async (call, args) =>
+            (await calls.Verify(async call =>
             {
-                (await (Task<string>) args[0]).ShouldBe(input);
+                (await (Task<string>) call.Args[0]).ShouldBe(input);
                 call.Return.ShouldBeNull();
             })).Count.ShouldBe(1);
             
@@ -311,9 +311,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             })).Count.ShouldBe(1);
             
-            (await calls.Verify<(Task<string> input, __)>(async (call, args) =>
+            (await calls.Verify<(Task<string> input, __)>(async call =>
             {
-                (await args.input).ShouldBe(input);
+                (await call.Args.input).ShouldBe(input);
                 call.Return.ShouldBeNull();
             })).Count.ShouldBe(1);
         }
@@ -333,14 +333,9 @@ namespace DivertR.UnitTests
             {
             });
 
-            Action verifyCallsWithArgs = () => calls.Verify<(int input, __)>((_, _) =>
-            {
-            });
-            
             // ASSERT
             verify.ShouldThrow<DiverterValidationException>();
             verifyCalls.ShouldThrow<DiverterValidationException>();
-            verifyCallsWithArgs.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
@@ -358,14 +353,9 @@ namespace DivertR.UnitTests
             {
             });
 
-            Action verifyCallsWithArgs = () => calls.Verify<(int input, __)>((_, _) =>
-            {
-            });
-            
             // ASSERT
             verify.ShouldThrow<DiverterValidationException>();
             verifyCalls.ShouldThrow<DiverterValidationException>();
-            verifyCallsWithArgs.ShouldThrow<DiverterValidationException>();
         }
         
         [Fact]
@@ -396,15 +386,15 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.Verify<(string input, __)>((call, args) =>
+            calls.Verify<(string input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.Args<(string input, __)>().Verify<(string input, __)>((call, args) =>
+            calls.Args<(string input, __)>().Verify<(string input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
         }
@@ -437,9 +427,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.Verify<(string input, __)>((call, args) =>
+            calls.Verify<(string input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
@@ -449,9 +439,9 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
-            calls.Verify<(object input, __)>((call, args) =>
+            calls.Verify<(object input, __)>(call =>
             {
-                args.input.ShouldBe(input);
+                call.Args.input.ShouldBe(input);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(1);
             
@@ -500,10 +490,10 @@ namespace DivertR.UnitTests
                 call.Return.ShouldBe(_foo.Echo((string) call.Args[0]));
             }).Count.ShouldBe(inputs.Length);
             
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args.Count.ShouldBe(1);
-                call.Return.ShouldBe(_foo.Echo((string) args[0]));
+                call.Args.Count.ShouldBe(1);
+                call.Return.ShouldBe(_foo.Echo((string) call.Args[0]));
             }).Count.ShouldBe(inputs.Length);
             
             calls.Args<(string input, __)>().Select((call, i) =>
@@ -524,7 +514,7 @@ namespace DivertR.UnitTests
             
             var calls = _fooRedirect
                 .To(x => x.Echo(Is<string>.Any))
-                .Via<(string input, __)>((call, args) => $"{call.Root.Echo(args.input)} redirected")
+                .Via<(string input, __)>(call => $"{call.Root.Echo(call.Args.input)} redirected")
                 .Record();
 
             // ACT
@@ -541,9 +531,9 @@ namespace DivertR.UnitTests
             }).Count.ShouldBe(inputs.Length);
             
             var count2 = 0;
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args.input.ShouldBe(inputs[count2]);
+                call.Args.input.ShouldBe(inputs[count2]);
                 call.Return.ShouldBe(results[count2++]);
             }).Count.ShouldBe(inputs.Length);
 
@@ -565,7 +555,7 @@ namespace DivertR.UnitTests
             
             var calls = _fooRedirect
                 .To(x => x.Echo(Is<string>.Any))
-                .Via<(string input, __)>((call, args) => $"{call.Next.Echo(args.input)} redirected")
+                .Via<(string input, __)>(call => $"{call.Next.Echo(call.Args.input)} redirected")
                 .Record();
 
             // ACT
@@ -582,9 +572,9 @@ namespace DivertR.UnitTests
             }).Count.ShouldBe(inputs.Length);
             
             var count2 = 0;
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args.input.ShouldBe(inputs[count2]);
+                call.Args.input.ShouldBe(inputs[count2]);
                 call.Return.ShouldBe(results[count2++]);
             }).Count.ShouldBe(inputs.Length);
         }
@@ -599,7 +589,7 @@ namespace DivertR.UnitTests
             
             var calls = _fooRedirect
                 .To(x => x.SetName(Is<string>.Any))
-                .Via<(string input, __)>((call, args) => call.Root.SetName($"{args.input} redirected"))
+                .Via<(string input, __)>(call => call.Root.SetName($"{call.Args.input} redirected"))
                 .Record();
 
             // ACT
@@ -620,9 +610,9 @@ namespace DivertR.UnitTests
             }).Count.ShouldBe(inputs.Length);
             
             var count2 = 0;
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args.input.ShouldBe(inputs[count2++]);
+                call.Args.input.ShouldBe(inputs[count2++]);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(inputs.Length);
         }
@@ -637,7 +627,7 @@ namespace DivertR.UnitTests
             
             var calls = _fooRedirect
                 .To(x => x.SetName(Is<string>.Any))
-                .Via<(string input, __)>((call, args) => call.Next.SetName($"{args.input} redirected"))
+                .Via<(string input, __)>(call => call.Next.SetName($"{call.Args.input} redirected"))
                 .Record();
 
             // ACT
@@ -661,9 +651,9 @@ namespace DivertR.UnitTests
             }).Count.ShouldBe(inputs.Length);
             
             var count2 = 0;
-            calls.Verify((call, args) =>
+            calls.Verify(call =>
             {
-                args.input.ShouldBe(inputs[count2++]);
+                call.Args.input.ShouldBe(inputs[count2++]);
                 call.Return.ShouldBeNull();
             }).Count.ShouldBe(inputs.Length);
         }
@@ -679,7 +669,7 @@ namespace DivertR.UnitTests
             var viaBuilder = _fooRedirect.To(x => x.Echo(Is<string>.Any));
             var calls = viaBuilder.Record();
             viaBuilder
-                .Via<(string input, __)>((call, args) => $"{call.Root.Echo(args.input)} redirected");
+                .Via<(string input, __)>(call => $"{call.Root.Echo(call.Args.input)} redirected");
 
             // ACT
             var results = inputs.Select(input => _proxy.Echo(input)).ToArray();
@@ -700,9 +690,9 @@ namespace DivertR.UnitTests
             var viaBuilder = _fooRedirect.To(x => x.Echo(Is<string>.Any));
             var calls = viaBuilder.Record<(string input, __)>();
             viaBuilder
-                .Via<(string input, __)>((call, args) =>
+                .Via<(string input, __)>(call =>
                 {
-                    var modifiedInput = $"{args.input} modified";
+                    var modifiedInput = $"{call.Args.input} modified";
                     return $"{call.Next.Echo(modifiedInput)} redirected";
                 });
 
@@ -730,9 +720,9 @@ namespace DivertR.UnitTests
             var viaBuilder = _fooRedirect.To(x => x.Echo(Is<string>.Any));
             var recordedCalls = viaBuilder.Record<(string input, __)>(opt => opt.OrderFirst());
             viaBuilder
-                .Via<(string input, __)>((call, args) =>
+                .Via<(string input, __)>(call =>
                 {
-                    var modifiedInput = $"{args.input} modified";
+                    var modifiedInput = $"{call.Args.input} modified";
                     return $"{call.Next.Echo(modifiedInput)} redirected";
                 });
 
@@ -760,9 +750,9 @@ namespace DivertR.UnitTests
             var viaBuilder = _fooRedirect.To(x => x.Echo(Is<string>.Any));
             var recordedCalls = viaBuilder.Record<(string input, __)>();
             viaBuilder
-                .Via<(string input, __)>((call, args) =>
+                .Via<(string input, __)>(call =>
                 {
-                    var modifiedInput = $"{args.input} modified";
+                    var modifiedInput = $"{call.Args.input} modified";
                     return $"{call.Next.Echo(modifiedInput)} redirected";
                 }, opt => opt.OrderLast());
 

--- a/test/DivertR.UnitTests/RedirectUpdaterTests.cs
+++ b/test/DivertR.UnitTests/RedirectUpdaterTests.cs
@@ -843,7 +843,7 @@ namespace DivertR.UnitTests
             
             _redirect
                 .To(x => x.Echo(Is<string>.Any))
-                .Via<(string input, __)>((call, args) => $"{call.Next.Echo(args.input)} diverted");
+                .Via<(string input, __)>(call => $"{call.Next.Echo(call.Args.input)} diverted");
             
             // ACT
             var result = proxy.Echo("test");
@@ -1047,7 +1047,7 @@ namespace DivertR.UnitTests
             var redirect = new Redirect<INumber>();
             redirect
                 .To(x => x.GetNumber(Is<int>.Any))
-                .Via<(int input, __)>((call, args) => call.Next.GetNumber(args.input) + 5);
+                .Via<(int input, __)>(call => call.Next.GetNumber(call.Args.input) + 5);
 
             // ACT
             var proxy = redirect.Proxy(new Number(x => x * 2));
@@ -1128,7 +1128,7 @@ namespace DivertR.UnitTests
                 .To(new CallConstraint<IFoo>(call => call.Method.ReturnType.IsAssignableFrom(typeof(string))))
                 .Via(() => "redirected")
                 .Via(call => $"{call.CallNext()} call {call.Args.LastOrDefault()}".Trim())
-                .Via((call, args) => $"{call.CallNext()} args {args.LastOrDefault()}".Trim());
+                .Via(call => $"{call.CallNext()} args {call.Args.LastOrDefault()}".Trim());
             
             var proxy = _redirect.Proxy();
 

--- a/test/DivertR.UnitTests/ValueTupleValidationTests.cs
+++ b/test/DivertR.UnitTests/ValueTupleValidationTests.cs
@@ -61,7 +61,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             _redirect
                 .To(x => x.EchoGeneric(Is<int>.Any, Is<int>.Any))
-                .Via<(int input, __)>((_, args) => (args.input, 0));
+                .Via<(int input, __)>(call => (call.Args.input, 0));
 
             // ACT
             var result = _redirect.Proxy().EchoGeneric(10, 100);

--- a/test/DivertR.UnitTests/ViaRedirectTests.cs
+++ b/test/DivertR.UnitTests/ViaRedirectTests.cs
@@ -109,12 +109,12 @@ namespace DivertR.UnitTests
             // ARRANGE
             var viaRedirect = _redirect
                 .To(x => x.EchoGeneric(Is<IList<string>>.Any))
-                .Via<(IList<string> input, __)>((_, args) => args.input.Select(x => $"via: {x}").ToList())
+                .Via<(IList<string> input, __)>(call => call.Args.input.Select(x => $"via: {x}").ToList())
                 .ViaRedirect();
             
             viaRedirect
                 .To(x => x[Is<int>.Any])
-                .Via<(int index, __)>((call, args) => call.Next[args.index] + " diverted");
+                .Via<(int index, __)>(call => call.Next[call.Args.index] + " diverted");
 
             IList<string> input = Enumerable.Range(0, 10).Select(x => $"test{x}").ToList();
             var divertedList = _proxy.EchoGeneric(input);

--- a/test/DivertR.WebAppTests/SpySampleTests.cs
+++ b/test/DivertR.WebAppTests/SpySampleTests.cs
@@ -203,9 +203,9 @@ namespace DivertR.WebAppTests
 
             // ASSERT
             response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
-            recordedCalls.Verify((call, args) =>
+            recordedCalls.Verify(call =>
             {
-                args.foo.Name.ShouldBe(createFooRequest.Name);
+                call.Args.foo.Name.ShouldBe(createFooRequest.Name);
                 call.Exception.ShouldBeSameAs(testException);
             }).Count.ShouldBe(1);
         }


### PR DESCRIPTION
Remove all occurrences of the second args convenience parameter of Via and Verify delegates.

1. The parameter was added for convenience only and does not provide any additional functionality.
2. The supporting code adds a lot of complexity.
3. The multiple input parameter delegates syntax is untidy.
4. Feedback received shows this feature is not used very much.