### PR TITLE
Rename IRedirectSet.Redirect methods to IRedirectSet.GetOrCreate

### DIFF
--- a/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DivertR/DependencyInjection/ServiceCollectionExtensions.cs
@@ -5,8 +5,20 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DivertR.DependencyInjection
 {
+    /// <summary>
+    /// Extension methods for installing an <see cref="IDiverter"/> instance into an <see href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> container.
+    /// </summary>
     public static class ServiceCollectionExtensions
     {
+        /// <summary>
+        /// Installs the <see cref="IRedirect"/> collection of registered types from the <paramref name="diverter"/> instance into the <paramref name="services"/> container.
+        /// The Redirects are embedded by decorating existing container registrations, of matching types, with proxy factories that produce <see cref="IRedirect"/> proxies wrapping the originals as their root instances.
+        /// </summary>
+        /// <param name="services">The services container.</param>
+        /// <param name="diverter">The Diverter instance.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the registered <see cref="IRedirect"/> group.</param>
+        /// <returns>The input services container.</returns>
+        /// <exception cref="DiverterException">Throws if either the <paramref name="diverter"/> instances contains registered types not in the <paramref name="services"/> or vice versa.</exception>
         public static IServiceCollection Divert(this IServiceCollection services, IDiverter diverter, string? name = null)
         {
             var decorateActions = CreateDecorateActions(services, diverter, name);

--- a/src/DivertR/Diverter.cs
+++ b/src/DivertR/Diverter.cs
@@ -32,7 +32,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverter Register<TTarget>(string? name = null) where TTarget : class?
         {
-            var redirect = RedirectSet.Redirect<TTarget>(name);
+            var redirect = RedirectSet.GetOrCreate<TTarget>(name);
 
             if (!_registeredRedirects.TryAdd(redirect.RedirectId, redirect))
             {
@@ -45,7 +45,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverter Register(Type targetType, string? name = null)
         {
-            var redirect = RedirectSet.Redirect(targetType, name);
+            var redirect = RedirectSet.GetOrCreate(targetType, name);
             
             if (!_registeredRedirects.TryAdd(redirect.RedirectId, redirect))
             {
@@ -67,6 +67,18 @@ namespace DivertR
         }
         
         /// <inheritdoc />
+        public IDiverter Register(params Type[] types)
+        {
+            return Register(types, null);
+        }
+        
+        /// <inheritdoc />
+        public IDiverter Register(string name, params Type[] types)
+        {
+            return Register(types, name);
+        }
+
+        /// <inheritdoc />
         public IEnumerable<IRedirect> RegisteredRedirects(string? name = null)
         {
             name ??= string.Empty;
@@ -83,15 +95,15 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IRedirect Redirect(Type targetType, string? name = null)
+        public IRedirect Redirect(Type type, string? name = null)
         {
-            return Redirect(RedirectId.From(targetType, name));
+            return Redirect(RedirectId.From(type, name));
         }
         
         /// <inheritdoc />
         public IRedirect Redirect(RedirectId redirectId)
         {
-            var redirect = RedirectSet.GetRedirect(redirectId);
+            var redirect = RedirectSet.Get(redirectId);
             
             if (redirect == null)
             {

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -4,98 +4,125 @@ using System.Collections.Generic;
 namespace DivertR
 {
     /// <summary>
-    /// The primary DivertR interface for registering and managing an <see cref="IRedirect"/> collection.
+    /// The DivertR interface used for managing a collection of <see cref="IRedirect"/> instances intended to be embedded in a dependency injection container.
+    ///
+    /// Use this interface to register the set of types intended to be diverted and a corresponding <see cref="IRedirect"/> gets created for each and added to the underlying <see cref="IRedirectSet"/>.
+    /// 
+    /// The registered <see cref="IRedirect"/> instances are exposed for embedding into a dependency injection container but this responsibility is left to the container specific implementation.
+    /// For example <see cref="DependencyInjection.ServiceCollectionExtensions.Divert"/> is an extension method that does this for the <see href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection" /> IServiceCollection container.
+    ///
+    /// This interface also acts as a facade around the underlying <see cref="IRedirectSet"/> for retrieving and managing <see cref="IRedirect"/> instances in the collection.   
     /// </summary>
     public interface IDiverter
     {
         /// <summary>
-        /// The <see cref="IRedirectSet"/> instance containing all <see cref="IRedirect"/> instances used by this <see cref="IDiverter"/>.
+        /// The underlying <see cref="IRedirectSet"/> containing the <see cref="IRedirect"/> collection of this <see cref="IDiverter"/> instance.
         /// </summary>
         IRedirectSet RedirectSet { get; }
         
         /// <summary>
-        /// Register an <see cref="IRedirect{TTarget}"/> for a given type.
+        /// Register a type to divert and add a corresponding <see cref="IRedirect{TTarget}"/> to the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <typeparam name="TTarget">The Redirect type.</typeparam>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/>.</param>
+        /// <typeparam name="TTarget">The type to register.</typeparam>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if the <typeparamref name="TTarget"/> type with matching <paramref name="name"/> has already been registered.</exception>
         IDiverter Register<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
-        /// Register an <see cref="IRedirect"/> for a given type.
+        /// Register a type to divert and add a corresponding <see cref="IRedirect"/> to the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="type">The Redirect type.</param>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="type">The type to register.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/>.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if the <paramref name="type"/> with matching <paramref name="name"/> has already been registered.</exception>
         IDiverter Register(Type type, string? name = null);
         
         /// <summary>
-        /// Register multiple <see cref="IRedirect"/>s for a given type collection.
+        /// Register multiple types to divert and add their corresponding <see cref="IRedirect{TTarget}"/> instances to the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="types">The Redirect types.</param>
-        /// <param name="name">The Redirect group name.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="types">The types to register.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/> instances.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if any <paramref name="types"/> with matching <paramref name="name"/> have already been registered.</exception>
         IDiverter Register(IEnumerable<Type> types, string? name = null);
         
         /// <summary>
-        /// Retrieve a group of registered <see cref="IRedirect"/>s.
+        /// Register multiple types to divert and add their corresponding <see cref="IRedirect"/> instances to the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="name">The Redirect group name.</param>
-        /// <returns>The registered <see cref="IRedirect"/> collection.</returns>
+        /// <param name="types">The types to register.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if any <paramref name="types"/> with default <see cref="RedirectId.Name" /> have already been registered.</exception>
+        IDiverter Register(params Type[] types);
+        
+        /// <summary>
+        /// Register multiple types to divert and add their corresponding <see cref="IRedirect"/> instances to the underlying <see cref="IRedirectSet"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/> instances.</param>
+        /// <param name="types">The types to register.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if any <paramref name="types"/> with matching <paramref name="name"/> have already been registered.</exception>
+        IDiverter Register(string name, params Type[] types);
+        
+        /// <summary>
+        /// Get a group of registered <see cref="IRedirect"/> instances having <see cref="RedirectId.Name" /> equal to <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the registered <see cref="IRedirect"/> instances.</param>
+        /// <returns>The <see cref="IRedirect"/> collection.</returns>
         IEnumerable<IRedirect> RegisteredRedirects(string? name = null);
         
         /// <summary>
-        /// Retrieve a registered <see cref="IRedirect{TTarget}" /> instance.
+        /// Get the <see cref="IRedirect{TTarget}"/> from the underlying <see cref="IRedirectSet"/> by <see cref="RedirectId"/> key generated from <typeparamref name="TTarget"/> and optional <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <typeparam name="TTarget">The Redirect type.</typeparam>
-        /// <returns>The registered <see cref="IRedirect{TTarget}" /> instance.</returns>
-        /// <exception cref="DiverterException">If the <see cref="IRedirect{TTarget}" /> has not been registered.</exception>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>
+        /// <typeparam name="TTarget">The <see cref="RedirectId.Type" /> of the <see cref="IRedirect"/>.</typeparam>
+        /// <returns>The <see cref="IRedirect{TTarget}" /> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if the underlying <see cref="IRedirectSet" /> does not contain a matching <see cref="IRedirect"/>.</exception>
         IRedirect<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
-        /// Retrieve a registered <see cref="IRedirect" /> instance.
+        /// Get the <see cref="IRedirect"/> from the underlying <see cref="IRedirectSet"/> by <paramref name="redirectId"/>
         /// </summary>
-        /// <param name="redirectId">The <see cref="IRedirect" /> id.</param>
-        /// <returns>The registered <see cref="IRedirect" /> instance.</returns>
-        /// <exception cref="DiverterException">If the <see cref="IRedirect" /> has not been registered.</exception>
+        /// <param name="redirectId">The <see cref="IRedirect"/> key.</param>
+        /// <returns>The <see cref="IRedirect" /> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if the underlying <see cref="IRedirectSet" /> does not contain a matching <see cref="IRedirect"/>.</exception>
         IRedirect Redirect(RedirectId redirectId);
         
         /// <summary>
-        /// Retrieve a registered <see cref="IRedirect" /> instance.
+        /// Get the <see cref="IRedirect"/> from the underlying <see cref="IRedirectSet"/> by <see cref="RedirectId"/> key generated from <paramref name="type"/> and optional <paramref name="name"/>.
         /// </summary>
-        /// <param name="targetType">The <see cref="IRedirect" /> type.</param>
-        /// <param name="name">The Redirect group name.</param>
-        /// <returns>The registered <see cref="IRedirect" /> instance.</returns>
-        /// <exception cref="DiverterException">If the <see cref="IRedirect" /> has not been registered.</exception>
-        IRedirect Redirect(Type targetType, string? name = null);
+        /// <param name="type">The <see cref="RedirectId.Type" /> of the <see cref="RedirectId"/>.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="RedirectId"/>.</param>
+        /// <returns>The <see cref="IRedirect" /> instance.</returns>
+        /// <exception cref="DiverterException">Thrown if the underlying <see cref="IRedirectSet" /> does not contain a matching <see cref="IRedirect"/>.</exception>
+        IRedirect Redirect(Type type, string? name = null);
         
         /// <summary>
-        /// Enable strict mode on all registered <see cref="IRedirect" />s.
+        /// Enable strict mode on all <see cref="IRedirect"/> instances in the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
         IDiverter StrictAll();
         
         /// <summary>
-        /// Enable strict mode on group of registered <see cref="IRedirect" />s.
+        /// Enable strict mode on an <see cref="IRedirect"/> group in the underlying <see cref="IRedirectSet"/> with name equal to <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The Redirect group name.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
         IDiverter Strict(string? name = null);
         
         /// <summary>
-        /// Reset all registered <see cref="IRedirect" />s.
+        /// Reset all <see cref="IRedirect"/> instances in the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent Redirects.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
         IDiverter ResetAll(bool includePersistent = false);
         
         /// <summary>
-        /// Reset registered <see cref="IRedirect" /> group.
+        /// Reset an <see cref="IRedirect"/> group in the underlying <see cref="IRedirectSet"/> set with name equal to <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The Redirect group name.</param>
-        /// <param name="includePersistent">Optionally also reset persistent Redirects.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
+        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
+        /// <returns>This <see cref="IDiverter"/> instance.</returns>
         IDiverter Reset(string? name = null, bool includePersistent = false);
     }
 }

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -9,7 +9,7 @@ namespace DivertR
     /// Use this interface to register the set of types intended to be diverted and a corresponding <see cref="IRedirect"/> gets created for each and added to the underlying <see cref="IRedirectSet"/>.
     /// 
     /// The registered <see cref="IRedirect"/> instances are exposed for embedding into a dependency injection container but this responsibility is left to the container specific implementation.
-    /// For example <see cref="DependencyInjection.ServiceCollectionExtensions.Divert"/> is an extension method that does this for the <see href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection" /> IServiceCollection container.
+    /// For example <see cref="DependencyInjection.ServiceCollectionExtensions.Divert"/> is an extension method that does this for the <see href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> container.
     ///
     /// This interface also acts as a facade around the underlying <see cref="IRedirectSet"/> for retrieving and managing <see cref="IRedirect"/> instances in the collection.   
     /// </summary>

--- a/src/DivertR/IRedirectSet.cs
+++ b/src/DivertR/IRedirectSet.cs
@@ -2,82 +2,88 @@
 
 namespace DivertR
 {
+    /// <summary>
+    /// Manages a set collection of <see cref="IRedirect"/> instances that are unique by <see cref="RedirectId"/> key.
+    /// </summary>
     public interface IRedirectSet
     {
         DiverterSettings Settings { get; }
         
         /// <summary>
-        /// Get or create a Redirect in this set for a given target type.
+        /// Get the <see cref="IRedirect{TTarget}"/> in this set by <see cref="RedirectId"/> key generated from <typeparamref name="TTarget"/> and optional <paramref name="name"/>.
+        /// If the <see cref="IRedirect"/> does not exist in this set, a new one is created and returned.
         /// </summary>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <typeparam name="TTarget">The Redirect target type.</typeparam>
-        /// <returns>The existing or created Redirect.</returns>
-        IRedirect<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?;
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>
+        /// <typeparam name="TTarget">The <see cref="RedirectId.Type" /> of the <see cref="IRedirect"/>.</typeparam>
+        /// <returns>The existing or created <see cref="IRedirect"/>.</returns>
+        IRedirect<TTarget> GetOrCreate<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
-        /// Get or create a Redirect in this set for a given target type.
+        /// Get the <see cref="IRedirect"/> in this set by <see cref="RedirectId"/> key generated from <paramref name="type"/> and optional <paramref name="name"/>.
+        /// If the <see cref="IRedirect"/> does not exist in this set, a new one is created and returned.
         /// </summary>
-        /// <param name="targetType">The Redirect target type.</param>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <returns>The existing or created Redirect.</returns>
-        IRedirect Redirect(Type targetType, string? name = null);
+        /// <param name="type">The <see cref="RedirectId.Type" /> of the <see cref="IRedirect"/>.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>
+        /// <returns>The existing or created <see cref="IRedirect"/>.</returns>
+        IRedirect GetOrCreate(Type type, string? name = null);
 
         /// <summary>
-        /// Get or create a Redirect in this set by id.
+        /// Get the <see cref="IRedirect"/> in this set by <paramref name="redirectId"/> key.
+        /// If the <see cref="IRedirect"/> does not exist in this set, a new one is created and returned.
         /// </summary>
-        /// <param name="redirectId">The Redirect id.</param>
-        /// <returns>The existing or created Redirect.</returns>
-        IRedirect Redirect(RedirectId redirectId);
+        /// <param name="redirectId">The <see cref="IRedirect"/> key.</param>
+        /// <returns>The existing or created <see cref="IRedirect"/>.</returns>
+        IRedirect GetOrCreate(RedirectId redirectId);
         
         /// <summary>
-        /// Get the Redirect in this set for a given target type.
+        /// Get the <see cref="IRedirect{TTarget}"/> in this set by <see cref="RedirectId"/> key generated from <typeparamref name="TTarget"/> and optional <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <typeparam name="TTarget">The Redirect target type.</typeparam>
-        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
-        IRedirect<TTarget>? GetRedirect<TTarget>(string? name = null) where TTarget : class?;
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>
+        /// <typeparam name="TTarget">The <see cref="RedirectId.Type" /> of the <see cref="IRedirect"/>.</typeparam>
+        /// <returns>The <see cref="IRedirect"/> instance or null if it does not exist in the set.</returns>
+        IRedirect<TTarget>? Get<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
-        /// Get a Redirect in this set for a given target type.
+        /// Get the <see cref="IRedirect"/> in this set by <see cref="RedirectId"/> key generated from <paramref name="type"/> and optional <paramref name="name"/>.
         /// </summary>
-        /// <param name="targetType">The Redirect target type.</param>
-        /// <param name="name">Optional Redirect group name.</param>
-        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
-        IRedirect? GetRedirect(Type targetType, string? name = null);
+        /// <param name="type">The <see cref="RedirectId.Type" /> of the <see cref="IRedirect"/>.</param>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>
+        /// <returns>The <see cref="IRedirect"/> instance or null if it does not exist in the set.</returns>
+        IRedirect? Get(Type type, string? name = null);
 
         /// <summary>
-        /// Get a Redirect in this set by id.
+        /// Get the <see cref="IRedirect"/> in this set by <paramref name="redirectId"/> key.
         /// </summary>
-        /// <param name="redirectId">The Redirect id.</param>
-        /// <returns>The Redirect instance or null if it does not exist in the set.</returns>
-        IRedirect? GetRedirect(RedirectId redirectId);
+        /// <param name="redirectId">The <see cref="IRedirect"/> key.</param>
+        /// <returns>The <see cref="IRedirect"/> instance or null if it does not exist in the set.</returns>
+        IRedirect? Get(RedirectId redirectId);
 
         /// <summary>
-        /// Reset the specified group of <see cref="IRedirect" />s in this set.
+        /// Reset an <see cref="IRedirect"/> group in this set with name equal to <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The Redirect group name.</param>
-        /// <param name="includePersistent">Optionally also reset persistent Redirects.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
+        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
+        /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
         IRedirectSet Reset(string? name = null, bool includePersistent = false);
         
         /// <summary>
-        /// Reset all <see cref="IRedirect" />s in this set.
+        /// Reset all <see cref="IRedirect"/> instances in this set.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent Redirects.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
+        /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
         IRedirectSet ResetAll(bool includePersistent = false);
         
         /// <summary>
-        /// Enable strict mode on the specified group of <see cref="IRedirect" />s in this set.
+        /// Enable strict mode on an <see cref="IRedirect"/> group in this set with name equal to <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The Redirect group name.</param>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
+        /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
         IRedirectSet Strict(string? name = null);
         
         /// <summary>
-        /// Enable strict mode on all <see cref="IRedirect" />s in this set.
+        /// Enable strict mode on all <see cref="IRedirect"/> instances in this set.
         /// </summary>
-        /// <returns>The current <see cref="IDiverter"/> instance.</returns>
+        /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
         IRedirectSet StrictAll();
     }
 }

--- a/src/DivertR/IRedirectSet.cs
+++ b/src/DivertR/IRedirectSet.cs
@@ -7,6 +7,9 @@ namespace DivertR
     /// </summary>
     public interface IRedirectSet
     {
+        /// <summary>
+        /// The <see cref="DiverterSettings" /> used by this set and all its <see cref="IRedirect"/> instances.
+        /// </summary>
         DiverterSettings Settings { get; }
         
         /// <summary>

--- a/src/DivertR/RedirectId.cs
+++ b/src/DivertR/RedirectId.cs
@@ -2,16 +2,31 @@
 
 namespace DivertR
 {
+    /// <summary>
+    /// A simple immutable struct intended to be used as an <see cref="IRedirect"/> composite key.
+    /// </summary>
     public readonly struct RedirectId : IEquatable<RedirectId>
     {
         private readonly (Type type, string name) _id;
         
+        /// <summary>
+        /// RedirectId constructor
+        /// </summary>
+        /// <param name="type">The <see cref="IRedirect"/> target type.</param>
+        /// <param name="name">The <see cref="IRedirect"/> target name.</param>
         public RedirectId(Type type, string? name = null)
         {
             _id = (type, name ?? string.Empty);
         }
-
+        
+        /// <summary>
+        /// The <see cref="IRedirect"/> target type.
+        /// </summary>
         public Type Type => _id.type;
+        
+        /// <summary>
+        /// The <see cref="IRedirect"/> target name.
+        /// </summary>
         public string Name => _id.name;
 
         public bool Equals(RedirectId other)
@@ -33,12 +48,24 @@ namespace DivertR
         {
             return $"Type:{Type.Name}" + (string.IsNullOrEmpty(Name) ? $" Name:<empty>" : $" Name: {Name}");
         }
-
+        
+        /// <summary>
+        /// Static wrapper for the <see cref="RedirectId"/> constructor
+        /// </summary>
+        /// <param name="type">The <see cref="IRedirect"/> target type.</param>
+        /// <param name="name">The <see cref="IRedirect"/> target name.</param>
+        /// <returns>The constructed <see cref="RedirectId"/> instance.</returns>
         public static RedirectId From(Type type, string? name = null)
         {
             return new RedirectId(type, name ?? string.Empty);
         }
-
+        
+        /// <summary>
+        /// Static wrapper for the <see cref="RedirectId"/> constructor
+        /// </summary>
+        /// <param name="name">The <see cref="IRedirect"/> target name.</param>
+        /// <typeparam name="TTarget">The <see cref="IRedirect{TTarget}"/> target type.</typeparam>
+        /// <returns>The constructed <see cref="RedirectId"/> instance.</returns>
         public static RedirectId From<TTarget>(string? name = null)
         {
             return new RedirectId(typeof(TTarget), name ?? string.Empty);

--- a/src/DivertR/RedirectId.cs
+++ b/src/DivertR/RedirectId.cs
@@ -13,7 +13,7 @@ namespace DivertR
         /// RedirectId constructor
         /// </summary>
         /// <param name="type">The <see cref="IRedirect"/> target type.</param>
-        /// <param name="name">The <see cref="IRedirect"/> target name.</param>
+        /// <param name="name">The <see cref="IRedirect"/> target name. If null defaults to <see cref="String.Empty"/></param>
         public RedirectId(Type type, string? name = null)
         {
             _id = (type, name ?? string.Empty);
@@ -57,7 +57,7 @@ namespace DivertR
         /// <returns>The constructed <see cref="RedirectId"/> instance.</returns>
         public static RedirectId From(Type type, string? name = null)
         {
-            return new RedirectId(type, name ?? string.Empty);
+            return new RedirectId(type, name);
         }
         
         /// <summary>
@@ -68,7 +68,7 @@ namespace DivertR
         /// <returns>The constructed <see cref="RedirectId"/> instance.</returns>
         public static RedirectId From<TTarget>(string? name = null)
         {
-            return new RedirectId(typeof(TTarget), name ?? string.Empty);
+            return new RedirectId(typeof(TTarget), name);
         }
     }
 }

--- a/src/DivertR/RedirectSet.cs
+++ b/src/DivertR/RedirectSet.cs
@@ -18,7 +18,7 @@ namespace DivertR
         public DiverterSettings Settings { get; }
         
         /// <inheritdoc />
-        public IRedirect<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?
+        public IRedirect<TTarget> GetOrCreate<TTarget>(string? name = null) where TTarget : class?
         {
             var redirectId = RedirectId.From<TTarget>(name);
             var redirectGroup = GetRedirectGroup(redirectId.Name);
@@ -28,15 +28,15 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IRedirect Redirect(Type targetType, string? name = null)
+        public IRedirect GetOrCreate(Type type, string? name = null)
         {
-            var redirectId = RedirectId.From(targetType, name);
+            var redirectId = RedirectId.From(type, name);
 
-            return Redirect(redirectId);
+            return GetOrCreate(redirectId);
         }
         
         /// <inheritdoc />
-        public IRedirect Redirect(RedirectId redirectId)
+        public IRedirect GetOrCreate(RedirectId redirectId)
         {
             IRedirect CreateRedirect(Type type)
             {
@@ -55,24 +55,24 @@ namespace DivertR
         }
 
         /// <inheritdoc />
-        public IRedirect<TTarget>? GetRedirect<TTarget>(string? name = null) where TTarget : class?
+        public IRedirect<TTarget>? Get<TTarget>(string? name = null) where TTarget : class?
         {
             var redirectId = RedirectId.From<TTarget>(name);
-            var redirect = GetRedirect(redirectId);
+            var redirect = Get(redirectId);
 
             return (IRedirect<TTarget>?) redirect;
         }
         
         /// <inheritdoc />
-        public IRedirect? GetRedirect(Type targetType, string? name = null)
+        public IRedirect? Get(Type type, string? name = null)
         {
-            var redirectId = RedirectId.From(targetType, name);
+            var redirectId = RedirectId.From(type, name);
 
-            return GetRedirect(redirectId);
+            return Get(redirectId);
         }
         
         /// <inheritdoc />
-        public IRedirect? GetRedirect(RedirectId redirectId)
+        public IRedirect? Get(RedirectId redirectId)
         {
             var redirectGroup = GetRedirectGroup(redirectId.Name);
             redirectGroup.TryGetValue(redirectId.Type, out var redirect);

--- a/src/DivertR/RedirectUpdaterExtensions.cs
+++ b/src/DivertR/RedirectUpdaterExtensions.cs
@@ -23,7 +23,7 @@ namespace DivertR
             }
             
             var proxyCache = new ConditionalWeakTable<TReturn, TReturn>();
-            var redirect = concreteRedirectUpdater.Redirect.RedirectSet.Redirect<TReturn>(name);
+            var redirect = concreteRedirectUpdater.Redirect.RedirectSet.GetOrCreate<TReturn>(name);
             
             TReturn ViaDelegate(IFuncRedirectCall<TTarget, TReturn> call)
             {

--- a/test/DivertR.UnitTests/ByRefInTests.cs
+++ b/test/DivertR.UnitTests/ByRefInTests.cs
@@ -13,7 +13,7 @@ namespace DivertR.UnitTests
         // https://github.com/dotnet/runtime/issues/47522
         private static readonly DiverterSettings DiverterSettings = new(proxyFactory: new DynamicProxy.DynamicProxyFactory());
 #endif
-        private readonly IRedirect<INumberIn> _redirect = new RedirectSet(DiverterSettings).Redirect<INumberIn>();
+        private readonly IRedirect<INumberIn> _redirect = new RedirectSet(DiverterSettings).GetOrCreate<INumberIn>();
 
         [Fact]
         public void GivenInParameterVia_ShouldRedirect()

--- a/test/DivertR.UnitTests/ByRefTests.cs
+++ b/test/DivertR.UnitTests/ByRefTests.cs
@@ -20,7 +20,7 @@ namespace DivertR.UnitTests
         public void GivenOutParameterVia_WhenException_ShouldWriteBackRefs()
         {
             // ARRANGE
-            var redirect = RedirectSet.Redirect<INumber>();
+            var redirect = RedirectSet.GetOrCreate<INumber>();
             redirect
                 .To(x => x.OutNumber(Is<int>.Any, out IsRef<int>.Any))
                 .Via<(int input, Ref<int> output)>(call =>
@@ -55,7 +55,7 @@ namespace DivertR.UnitTests
         protected ByRefTests(IRedirectSet redirectSet)
         {
             RedirectSet = redirectSet;
-            _redirect = redirectSet.Redirect<INumber>();
+            _redirect = redirectSet.GetOrCreate<INumber>();
             _proxy = _redirect.Proxy(new Number(i => i + 100));
         }
 

--- a/test/DivertR.UnitTests/DiverterTests.cs
+++ b/test/DivertR.UnitTests/DiverterTests.cs
@@ -15,6 +15,71 @@ namespace DivertR.UnitTests
         }
         
         [Fact]
+        public void GivenRegisteredType_WhenSameGenericTypeRegisteredWithDifferentName_ShouldRegister()
+        {
+            // ARRANGE
+
+            // ACT
+            _diverter.Register<IFoo>("test");
+            
+            // ASSERT
+            _diverter.Redirect<IFoo>("test").ShouldNotBeNull();
+        }
+        
+        [Fact]
+        public void GivenRegisteredType_WhenSameTypeRegisteredWithDifferentName_ShouldRegister()
+        {
+            // ARRANGE
+
+            // ACT
+            _diverter.Register(typeof(IFoo), "test");
+            
+            // ASSERT
+            _diverter.Redirect<IFoo>("test").ShouldNotBeNull();
+        }
+        
+        [Fact]
+        public void GivenRegisteredType_WhenSameTypeRegistered_ShouldThrowDiverterException()
+        {
+            // ARRANGE
+            _diverter.Register<IFoo>("test");
+
+            // ACT
+            var testAction = () => _diverter.Register<IFoo>("test");
+            
+            // ASSERT
+            testAction.ShouldThrow<DiverterException>();
+        }
+        
+        [Fact]
+        public void GivenDiverter_WhenParamsOfTypesRegistered_ShouldRegister()
+        {
+            // ARRANGE
+
+            // ACT
+            _diverter.Register(typeof(IList<int>), typeof(IList<string>), typeof(IList<object>));
+            
+            // ASSERT
+            _diverter.Redirect<IList<int>>().ShouldNotBeNull();
+            _diverter.Redirect<IList<string>>().ShouldNotBeNull();
+            _diverter.Redirect<IList<object>>().ShouldNotBeNull();
+        }
+        
+        [Fact]
+        public void GivenDiverter_WhenNamedParamsOfTypesRegistered_ShouldRegister()
+        {
+            // ARRANGE
+
+            // ACT
+            _diverter.Register("test", typeof(IList<int>), typeof(IList<string>), typeof(IList<object>));
+            
+            // ASSERT
+            _diverter.Redirect<IList<int>>("test").ShouldNotBeNull();
+            _diverter.Redirect<IList<string>>("test").ShouldNotBeNull();
+            _diverter.Redirect<IList<object>>("test").ShouldNotBeNull();
+        }
+        
+        [Fact]
         public void GivenRetargetWithRelay_ShouldRedirect()
         {
             // ARRANGE

--- a/test/DivertR.UnitTests/RedirectClassTests.cs
+++ b/test/DivertR.UnitTests/RedirectClassTests.cs
@@ -13,7 +13,7 @@ namespace DivertR.UnitTests
 
         public RedirectClassTests()
         {
-            _redirect = new RedirectSet(DiverterSettings).Redirect<Foo>();
+            _redirect = new RedirectSet(DiverterSettings).GetOrCreate<Foo>();
         }
         
         [Fact]

--- a/test/DivertR.UnitTests/RedirectSetTests.cs
+++ b/test/DivertR.UnitTests/RedirectSetTests.cs
@@ -17,10 +17,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddRedirect_ThenReturnsExistingFooRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
         
         // ACT
-        var testRedirect = _redirectSet.Redirect<IFoo>();
+        var testRedirect = _redirectSet.GetOrCreate<IFoo>();
         
         // ASSERT
         testRedirect.ShouldNotBeNull();
@@ -31,10 +31,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetOrAddSameNamedRedirect_ThenReturnsExistingFooRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>("test");
         
         // ACT
-        var testRedirect = _redirectSet.Redirect<IFoo>("test");
+        var testRedirect = _redirectSet.GetOrCreate<IFoo>("test");
         
         // ASSERT
         testRedirect.ShouldNotBeNull();
@@ -45,10 +45,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddNamedRedirect_ThenCreatesNewFooRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
         
         // ACT
-        var testRedirect = _redirectSet.Redirect<IFoo>("test");
+        var testRedirect = _redirectSet.GetOrCreate<IFoo>("test");
         
         // ASSERT
         testRedirect.ShouldNotBeNull();
@@ -59,10 +59,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetOrAddRedirectByType_ThenReturnsExistingFooRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
         
         // ACT
-        var testRedirect = _redirectSet.Redirect(typeof(IFoo));
+        var testRedirect = _redirectSet.GetOrCreate(typeof(IFoo));
         
         // ASSERT
         testRedirect.ShouldNotBeNull();
@@ -75,7 +75,7 @@ public class RedirectSetTests
         // ARRANGE
 
         // ACT
-        var result = _redirectSet.GetRedirect<IFoo>();
+        var result = _redirectSet.Get<IFoo>();
         
         // ASSERT
         result.ShouldBeNull();
@@ -87,7 +87,7 @@ public class RedirectSetTests
         // ARRANGE
 
         // ACT
-        var result = _redirectSet.GetRedirect(typeof(IFoo));
+        var result = _redirectSet.Get(typeof(IFoo));
         
         // ASSERT
         result.ShouldBeNull();
@@ -99,7 +99,7 @@ public class RedirectSetTests
         // ARRANGE
 
         // ACT
-        var result = _redirectSet.GetRedirect(RedirectId.From<IFoo>());
+        var result = _redirectSet.Get(RedirectId.From<IFoo>());
         
         // ASSERT
         result.ShouldBeNull();
@@ -109,10 +109,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetRedirect_ThenReturnsNull()
     {
         // ARRANGE
-        _redirectSet.Redirect<IFoo>("test");
+        _redirectSet.GetOrCreate<IFoo>("test");
 
         // ACT
-        var result = _redirectSet.GetRedirect<IFoo>();
+        var result = _redirectSet.Get<IFoo>();
         
         // ASSERT
         result.ShouldBeNull();
@@ -122,10 +122,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirect_ThenReturnsRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
 
         // ACT
-        var result = _redirectSet.GetRedirect<IFoo>();
+        var result = _redirectSet.Get<IFoo>();
         
         // ASSERT
         result.ShouldNotBeNull();
@@ -136,10 +136,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetNamedRedirect_ThenReturnsRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>("test");
 
         // ACT
-        var result = _redirectSet.GetRedirect<IFoo>("test");
+        var result = _redirectSet.Get<IFoo>("test");
         
         // ASSERT
         result.ShouldNotBeNull();
@@ -150,10 +150,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirectByType_ThenReturnsRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
 
         // ACT
-        var result = _redirectSet.GetRedirect(typeof(IFoo));
+        var result = _redirectSet.Get(typeof(IFoo));
         
         // ASSERT
         result.ShouldNotBeNull();
@@ -164,10 +164,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithFooRedirectAdded_WhenGetRedirectById_ThenReturnsRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>();
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>();
 
         // ACT
-        var result = _redirectSet.GetRedirect(RedirectId.From<IFoo>());
+        var result = _redirectSet.Get(RedirectId.From<IFoo>());
         
         // ASSERT
         result.ShouldNotBeNull();
@@ -178,10 +178,10 @@ public class RedirectSetTests
     public void GivenRedirectSetWithNamedFooRedirectAdded_WhenGetNamedRedirectByType_ThenReturnsRedirect()
     {
         // ARRANGE
-        var fooRedirect = _redirectSet.Redirect<IFoo>("test");
+        var fooRedirect = _redirectSet.GetOrCreate<IFoo>("test");
 
         // ACT
-        var result = _redirectSet.GetRedirect(typeof(IFoo), "test");
+        var result = _redirectSet.Get(typeof(IFoo), "test");
         
         // ASSERT
         result.ShouldNotBeNull();

--- a/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
+++ b/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
@@ -24,7 +24,7 @@ namespace DivertR.WebAppTests.TestHarness
         public WebAppFixture()
         {
             // Create an xUnit ITestOutputHelper proxy mock
-            var outputHelperMock = _diverter.RedirectSet.Redirect<ITestOutputHelper>().Proxy();
+            var outputHelperMock = _diverter.RedirectSet.GetOrCreate<ITestOutputHelper>().Proxy();
             
             _webApplicationFactory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
             {


### PR DESCRIPTION
Rename `IRedirectSet.Redirect` methods to `IRedirectSet.GetOrCreate` to say more clearly what it does and to remove ambiguity with the naming of `IDiverter.Redirect` methods.