### PR TITLE
Remove ability to reset persistent vias

### DIFF
--- a/src/DivertR/Diverter.cs
+++ b/src/DivertR/Diverter.cs
@@ -130,17 +130,17 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IDiverter ResetAll(bool includePersistent = false)
+        public IDiverter ResetAll()
         {
-            RedirectSet.ResetAll(includePersistent);
+            RedirectSet.ResetAll();
             
             return this;
         }
         
         /// <inheritdoc />
-        public IDiverter Reset(string? name = null, bool includePersistent = false)
+        public IDiverter Reset(string? name = null)
         {
-            RedirectSet.Reset(name, includePersistent);
+            RedirectSet.Reset(name);
 
             return this;
         }

--- a/src/DivertR/IActionRedirectCall.cs
+++ b/src/DivertR/IActionRedirectCall.cs
@@ -3,14 +3,6 @@ using System.Collections;
 
 namespace DivertR
 {
-    public interface IActionRedirectCall : IRedirectCall
-    {
-        new void CallNext();
-        new void CallNext(CallArguments args);
-        new void CallRoot();
-        new void CallRoot(CallArguments args);
-    }
-    
     public interface IActionRedirectCall<TTarget> : IRedirectCall<TTarget> where TTarget : class?
     {
     }

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -113,16 +113,14 @@ namespace DivertR
         /// <summary>
         /// Reset all <see cref="IRedirect"/> instances in the underlying <see cref="IRedirectSet"/>.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
         /// <returns>This <see cref="IDiverter"/> instance.</returns>
-        IDiverter ResetAll(bool includePersistent = false);
+        IDiverter ResetAll();
         
         /// <summary>
         /// Reset an <see cref="IRedirect"/> group in the underlying <see cref="IRedirectSet"/> set with name equal to <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
         /// <returns>This <see cref="IDiverter"/> instance.</returns>
-        IDiverter Reset(string? name = null, bool includePersistent = false);
+        IDiverter Reset(string? name = null);
     }
 }

--- a/src/DivertR/IRedirect.cs
+++ b/src/DivertR/IRedirect.cs
@@ -71,9 +71,8 @@ namespace DivertR
         /// <summary>
         /// Reset the Redirect's <see cref="IRedirectRepository" /> to its initial state.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This Redirect instance.</returns>
-        IRedirect Reset(bool includePersistent = false);
+        IRedirect Reset();
 
         /// <summary>
         /// Set strict mode on the Redirect.
@@ -139,9 +138,8 @@ namespace DivertR
         /// <summary>
         /// Reset the Redirect's <see cref="IRedirectRepository" /> to its initial state.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This Redirect instance.</returns>
-        new IRedirect<TTarget> Reset(bool includePersistent = false);
+        new IRedirect<TTarget> Reset();
         
         /// <summary>
         /// Set strict mode on the Redirect.

--- a/src/DivertR/IRedirectRepository.cs
+++ b/src/DivertR/IRedirectRepository.cs
@@ -41,33 +41,29 @@ namespace DivertR
         /// <summary>
         /// Reset the <see cref="RedirectPlan" /> to its initial state.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This <see cref="IRedirectRepository"/> instance.</returns>
-        IRedirectRepository Reset(bool includePersistent = false);
+        IRedirectRepository Reset();
 
         /// <summary>
         /// Reset the <see cref="RedirectPlan" /> and atomically insert the given <paramref name="via"/>.
         /// </summary>
         /// <param name="via">The Via instance to insert after reset.</param>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This <see cref="IRedirectRepository"/> instance.</returns>
-        IRedirectRepository ResetAndInsert(IVia via, bool includePersistent = false);
+        IRedirectRepository ResetAndInsert(IVia via);
 
         /// <summary>
         /// Resets the <see cref="RedirectPlan" /> and atomically insert the given <paramref name="via"/>.
         /// </summary>
         /// <param name="via">The Via instance to insert after reset.</param>
         /// <param name="viaOptions">The Via options.</param>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This <see cref="IRedirectRepository"/> instance.</returns>
-        IRedirectRepository ResetAndInsert(IVia via, ViaOptions viaOptions, bool includePersistent = false);
+        IRedirectRepository ResetAndInsert(IVia via, ViaOptions viaOptions);
 
         /// <summary>
         /// Reset the <see cref="RedirectPlan" /> and atomically insert the given <paramref name="configuredVia"/>.
         /// </summary>
         /// <param name="configuredVia">The configured Via instance to insert after reset.</param>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This <see cref="IRedirectRepository"/> instance.</returns>
-        IRedirectRepository ResetAndInsert(IConfiguredVia configuredVia, bool includePersistent = false);
+        IRedirectRepository ResetAndInsert(IConfiguredVia configuredVia);
     }
 }

--- a/src/DivertR/IRedirectSet.cs
+++ b/src/DivertR/IRedirectSet.cs
@@ -65,16 +65,14 @@ namespace DivertR
         /// Reset an <see cref="IRedirect"/> group in this set with name equal to <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/> group.</param>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
         /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
-        IRedirectSet Reset(string? name = null, bool includePersistent = false);
+        IRedirectSet Reset(string? name = null);
         
         /// <summary>
         /// Reset all <see cref="IRedirect"/> instances in this set.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/> registrations.</param>
         /// <returns>This <see cref="IRedirectSet"/> instance.</returns>
-        IRedirectSet ResetAll(bool includePersistent = false);
+        IRedirectSet ResetAll();
         
         /// <summary>
         /// Enable strict mode on an <see cref="IRedirect"/> group in this set with name equal to <paramref name="name"/>.

--- a/src/DivertR/ISpy.cs
+++ b/src/DivertR/ISpy.cs
@@ -36,9 +36,8 @@ namespace DivertR
         /// <summary>
         /// Reset the Spy's <see cref="IRedirectRepository" /> to its initial state.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This Spy instance.</returns>
-        new ISpy Reset(bool includePersistent = false);
+        new ISpy Reset();
         
         /// <summary>
         /// Set strict mode on the Spy.
@@ -76,9 +75,8 @@ namespace DivertR
         /// <summary>
         /// Reset the Spy's <see cref="IRedirectRepository" /> to its initial state.
         /// </summary>
-        /// <param name="includePersistent">Optionally also reset persistent <see cref="IVia"/>s.</param>
         /// <returns>This Spy instance.</returns>
-        new ISpy<TTarget> Reset(bool includePersistent = false);
+        new ISpy<TTarget> Reset();
         
         /// <summary>
         /// Set strict mode on the Spy.

--- a/src/DivertR/Redirect.cs
+++ b/src/DivertR/Redirect.cs
@@ -139,9 +139,9 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        IRedirect IRedirect.Reset(bool includePersistent)
+        IRedirect IRedirect.Reset()
         {
-            return Reset(includePersistent);
+            return Reset();
         }
         
         /// <inheritdoc />
@@ -151,9 +151,9 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IRedirect<TTarget> Reset(bool includePersistent = false)
+        public IRedirect<TTarget> Reset()
         {
-            ResetInternal(includePersistent);
+            ResetInternal();
 
             return this;
         }
@@ -204,9 +204,9 @@ namespace DivertR
             return new ActionRedirectUpdater<TTarget>(this, ViaBuilder<TTarget>.ToSetInternal(memberExpression, constraintExpression));
         }
         
-        protected virtual void ResetInternal(bool includePersistent)
+        protected virtual void ResetInternal()
         {
-            RedirectRepository.Reset(includePersistent);
+            RedirectRepository.Reset();
         }
     }
 }

--- a/src/DivertR/RedirectSet.cs
+++ b/src/DivertR/RedirectSet.cs
@@ -81,25 +81,25 @@ namespace DivertR
         }
 
         /// <inheritdoc />
-        public IRedirectSet Reset(string? name = null, bool includePersistent = false)
+        public IRedirectSet Reset(string? name = null)
         {
             var redirectGroup = GetRedirectGroup(name);
             foreach (var redirect in redirectGroup.Values)
             {
-                redirect.Reset(includePersistent);
+                redirect.Reset();
             }
 
             return this;
         }
         
         /// <inheritdoc />
-        public IRedirectSet ResetAll(bool includePersistent = false)
+        public IRedirectSet ResetAll()
         {
             foreach (var redirectGroup in _redirectGroups.Values)
             {
                 foreach (var redirect in redirectGroup.Values)
                 {
-                    redirect.Reset(includePersistent);
+                    redirect.Reset();
                 }
             }
 

--- a/src/DivertR/Spy.cs
+++ b/src/DivertR/Spy.cs
@@ -26,7 +26,7 @@ namespace DivertR
         {
             Mock = hasRoot ? Proxy() : Proxy(root);
             Spy.AddSpy(this, Mock);
-            ResetAndConfigureRecord(false);
+            ResetAndConfigureRecord();
         }
         
         /// <inheritdoc />
@@ -48,9 +48,9 @@ namespace DivertR
             return this;
         }
 
-        ISpy ISpy.Reset(bool includePersistent)
+        ISpy ISpy.Reset()
         {
-            base.Reset(includePersistent);
+            base.Reset();
 
             return this;
         }
@@ -70,9 +70,9 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public new ISpy<TTarget> Reset(bool includePersistent = false)
+        public new ISpy<TTarget> Reset()
         {
-            base.Reset(includePersistent);
+            base.Reset();
 
             return this;
         }
@@ -93,19 +93,19 @@ namespace DivertR
             return this;
         }
         
-        protected override void ResetInternal(bool includePersistent)
+        protected override void ResetInternal()
         {
-            ResetAndConfigureRecord(includePersistent);
+            ResetAndConfigureRecord();
         }
         
-        private void ResetAndConfigureRecord(bool includePersistent)
+        private void ResetAndConfigureRecord()
         {
             var recordHandler = new RecordCallHandler<TTarget>();
             // Only record calls going to the Mock proxy
             var callConstraint = new CallConstraint<TTarget>(call => ReferenceEquals(call.Proxy, Mock));
             var via = ViaBuilder<TTarget>.To(callConstraint).Build(recordHandler);
             var options = ViaOptionsBuilder.Create(opt => opt.OrderFirst(), disableSatisfyStrict: true);
-            RedirectRepository.ResetAndInsert(via, options, includePersistent);
+            RedirectRepository.ResetAndInsert(via, options);
             CallsLocked = recordHandler.RecordStream;
         }
 

--- a/test/DivertR.UnitTests/DiverterTests.cs
+++ b/test/DivertR.UnitTests/DiverterTests.cs
@@ -128,25 +128,7 @@ namespace DivertR.UnitTests
             // ASSERT
             subject.Name.ShouldBe("hello foo me again");
         }
-        
-        [Fact]
-        public void GivenPersistentVias_WhenResetAllIncludingPersistent_ShouldReset()
-        {
-            // ARRANGE
-            var original = new Foo("hello foo");
-            var redirect = _diverter.Redirect<IFoo>();
-            var subject = redirect.Proxy(original);
-            
-            redirect.Retarget(new FooAlt(() => $"{redirect.Relay.CallNext()} me"), opt => opt.Persist());
-            redirect.Retarget(new FooAlt(() => $"{redirect.Relay.CallNext()} again"), opt => opt.Persist());
 
-            // ACT
-            _diverter.ResetAll(includePersistent: true);
-            
-            // ASSERT
-            subject.Name.ShouldBe(original.Name);
-        }
-        
         [Fact]
         public void GivenVias_WhenResetGroup_ShouldReset()
         {
@@ -182,25 +164,7 @@ namespace DivertR.UnitTests
             // ASSERT
             subject.Name.ShouldBe("hello foo me again");
         }
-        
-        [Fact]
-        public void GivenPersistentVias_WhenResetGroupIncludingPersistent_ShouldReset()
-        {
-            // ARRANGE
-            var original = new Foo("hello foo");
-            var redirect = _diverter.Redirect<IFoo>();
-            var subject = redirect.Proxy(original);
-            
-            redirect.Retarget(new FooAlt(() => $"{redirect.Relay.CallNext()} me"), opt => opt.Persist());
-            redirect.Retarget(new FooAlt(() => $"{redirect.Relay.CallNext()} again"), opt => opt.Persist());
 
-            // ACT
-            _diverter.Reset(includePersistent: true);
-            
-            // ASSERT
-            subject.Name.ShouldBe(original.Name);
-        }
-        
         [Fact]
         public void GivenRegisteredRedirect_ShouldSetStrict()
         {

--- a/test/DivertR.UnitTests/RedirectRepositoryTests.cs
+++ b/test/DivertR.UnitTests/RedirectRepositoryTests.cs
@@ -29,23 +29,7 @@ public class RedirectRepositoryTests
         beforeName.ShouldBe("Redirect");
         _fooProxy.Name.ShouldBe("Replaced");
     }
-    
-    [Fact]
-    public void GivenExistingPersistentVia_WhenResetAndInsertViaIncludingPersistent_ThenResetsAndInsertsVia()
-    {
-        // ARRANGE
-        _fooRedirect.To(x => x.Name).Via("Redirect", opt => opt.Persist());
-        var beforeName = _fooProxy.Name;
 
-        // ACT
-        var replaceVia = ViaBuilder<IFoo>.To(x => x.Name).Build("Replaced");
-        _fooRedirect.RedirectRepository.ResetAndInsert(replaceVia, true);
-        
-        // ASSERT
-        beforeName.ShouldBe("Redirect");
-        _fooProxy.Name.ShouldBe("Replaced");
-    }
-    
     [Fact]
     public void GivenExistingPersistentVia_WhenResetAndInsertVia_ThenAddsVia()
     {

--- a/test/DivertR.UnitTests/RedirectTests.cs
+++ b/test/DivertR.UnitTests/RedirectTests.cs
@@ -124,24 +124,7 @@ namespace DivertR.UnitTests
             // ASSERT
             proxy.Name.ShouldBe("foo changed");
         }
-        
-        [Fact]
-        public void GivenPersistentVia_WhenResetIncludingPersistent_ShouldRemoveVia()
-        {
-            // ARRANGE
-            var proxy = _redirect.Proxy(new Foo("foo"));
-            
-            _redirect
-                .To(x => x.Name)
-                .Via(call => call.CallNext() + " changed", opt => opt.Persist());
-            
-            // ACT
-            _redirect.Reset(includePersistent: true);
 
-            // ASSERT
-            proxy.Name.ShouldBe("foo");
-        }
-        
         [Fact]
         public void GivenPersistentViaFollowedByNormalVia_ShouldViaChain()
         {
@@ -183,28 +166,7 @@ namespace DivertR.UnitTests
             // ASSERT
             proxy.Name.ShouldBe("foo changed");
         }
-        
-        [Fact]
-        public void GivenPersistentViaFollowedByNormalVia_WhenRedirectResetIncludingPersistent_ShouldResetAll()
-        {
-            // ARRANGE
-            var proxy = _redirect.Proxy(new Foo("foo"));
-            
-            _redirect
-                .To(x => x.Name)
-                .Via(call => call.CallNext() + " changed", opt => opt.Persist());
-            
-            _redirect
-                .To(x => x.Name)
-                .Via(call => call.CallNext() + " again");
-            
-            // ACT
-            _redirect.Reset(includePersistent: true);
 
-            // ASSERT
-            proxy.Name.ShouldBe("foo");
-        }
-        
         [Fact]
         public void GivenNormalViaFollowedByPersistentVia_WhenRedirectReset_ShouldKeepPersistentVia()
         {


### PR DESCRIPTION
Remove the option of including persistent vias when resetting. This adds unnecessary complexity and is a contradictory use case.