### PR TITLE
Remove Clone methods from ICallInfo interface

### DIFF
--- a/src/DivertR/ICallInfo.cs
+++ b/src/DivertR/ICallInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -6,6 +7,12 @@ namespace DivertR
 {
     public interface ICallInfo
     {
+        public Type TargetType
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
+        
         object Proxy
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -29,9 +36,6 @@ namespace DivertR
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;
         }
-
-        public ICallInfo Clone(CallArguments args);
-        public ICallInfo Clone(MethodInfo method, CallArguments args);
     }
     
     public interface ICallInfo<out TTarget> : ICallInfo where TTarget : class?
@@ -48,8 +52,5 @@ namespace DivertR
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;
         }
-        
-        new ICallInfo<TTarget> Clone(MethodInfo method, CallArguments args);
-        new ICallInfo<TTarget> Clone(CallArguments args);
     }
 }

--- a/src/DivertR/Internal/CallInfo.cs
+++ b/src/DivertR/Internal/CallInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -13,6 +14,12 @@ namespace DivertR.Internal
             Root = root;
             Method = method;
             Arguments = arguments;
+        }
+        
+        public Type TargetType
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => typeof(TTarget);
         }
         
         [NotNull]
@@ -51,25 +58,15 @@ namespace DivertR.Internal
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;
         }
-        
-        public ICallInfo<TTarget> Clone(MethodInfo method, CallArguments args)
+
+        public CallInfo<TTarget> From(MethodInfo method, CallArguments args)
         {
             return new CallInfo<TTarget>(Proxy, Root, method, args);
         }
 
-        public ICallInfo<TTarget> Clone(CallArguments args)
+        public CallInfo<TTarget> From(CallArguments args)
         {
             return new CallInfo<TTarget>(Proxy, Root, Method, args);
-        }
-
-        ICallInfo ICallInfo.Clone(MethodInfo method, CallArguments args)
-        {
-            return Clone(method, args);
-        }
-
-        ICallInfo ICallInfo.Clone(CallArguments args)
-        {
-            return Clone(args);
         }
     }
 }

--- a/src/DivertR/Internal/RedirectCall.cs
+++ b/src/DivertR/Internal/RedirectCall.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace DivertR.Internal
 {
-    internal class RedirectCall : IRedirectCall
+    internal abstract class RedirectCall : IRedirectCall
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected RedirectCall(IRelay relay, ICallInfo callInfo)

--- a/src/DivertR/Internal/Relay.cs
+++ b/src/DivertR/Internal/Relay.cs
@@ -47,7 +47,7 @@ namespace DivertR.Internal
         {
             var relayIndex = GetRelayIndexStack().Peek();
             ValidateStrict(relayIndex);
-            var callInfo = relayIndex.CallInfo.Clone(method, args);
+            var callInfo = relayIndex.CallInfo.From(method, args);
             
             return CallRoot(callInfo);
         }
@@ -57,7 +57,7 @@ namespace DivertR.Internal
         {
             var relayIndex = GetRelayIndexStack().Peek();
             ValidateStrict(relayIndex);
-            var callInfo = relayIndex.CallInfo.Clone(args);
+            var callInfo = relayIndex.CallInfo.From(args);
             
             return CallRoot(callInfo);
         }
@@ -108,7 +108,7 @@ namespace DivertR.Internal
         {
             var relayIndexStack = GetRelayIndexStack();
             var relayIndex = relayIndexStack.Peek();
-            var callInfo = relayIndex.CallInfo.Clone(method, args);
+            var callInfo = relayIndex.CallInfo.From(method, args);
             var relayNext = relayIndex.MoveNext(callInfo);
 
             if (relayNext == null)
@@ -136,7 +136,7 @@ namespace DivertR.Internal
         {
             var relayIndexStack = GetRelayIndexStack();
             var relayIndex = relayIndexStack.Peek();
-            var callInfo = relayIndex.CallInfo.Clone(args);
+            var callInfo = relayIndex.CallInfo.From(args);
             var relayNext = relayIndex.MoveNext(callInfo);
 
             if (relayNext == null)
@@ -160,7 +160,7 @@ namespace DivertR.Internal
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal object? CallBegin(IRedirectPlan redirectPlan, ICallInfo<TTarget> callInfo)
+        internal object? CallBegin(IRedirectPlan redirectPlan, CallInfo<TTarget> callInfo)
         {
             var relayIndex = RelayIndex<TTarget>.Create(redirectPlan, callInfo);
 

--- a/src/DivertR/Internal/RelayIndex.cs
+++ b/src/DivertR/Internal/RelayIndex.cs
@@ -14,7 +14,7 @@ namespace DivertR.Internal
             get;
         }
         
-        public ICallInfo<TTarget> CallInfo
+        public CallInfo<TTarget> CallInfo
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;
@@ -27,7 +27,7 @@ namespace DivertR.Internal
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RelayIndex<TTarget>? Create(IRedirectPlan redirectPlan, ICallInfo<TTarget> callInfo)
+        public static RelayIndex<TTarget>? Create(IRedirectPlan redirectPlan, CallInfo<TTarget> callInfo)
         {
             var index = GetNextIndex(-1, redirectPlan.Vias, callInfo);
 
@@ -42,7 +42,7 @@ namespace DivertR.Internal
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private RelayIndex(IRedirectPlan redirectPlan, int index, ICallInfo<TTarget> callInfo, bool strictSatisfied)
+        private RelayIndex(IRedirectPlan redirectPlan, int index, CallInfo<TTarget> callInfo, bool strictSatisfied)
         {
             _redirectPlan = redirectPlan;
             CallInfo = callInfo;
@@ -51,7 +51,7 @@ namespace DivertR.Internal
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public RelayIndex<TTarget>? MoveNext(ICallInfo<TTarget> callInfo)
+        public RelayIndex<TTarget>? MoveNext(CallInfo<TTarget> callInfo)
         {
             var index = GetNextIndex(_index, _redirectPlan.Vias, callInfo);
 


### PR DESCRIPTION
Remove Clone methods from public `ICallInfo` interface as they are internal implementation details.