### PR TITLE
Cache redirect proxies against root instances

### DIFF
--- a/src/DivertR/DiverterSettings.cs
+++ b/src/DivertR/DiverterSettings.cs
@@ -18,6 +18,8 @@ namespace DivertR
         
         public bool DefaultWithDummyRoot { get; }
 
+        public bool CacheRedirectProxies { get; }
+
         public IDummyFactory DummyFactory { get; }
         
         public ICallInvoker CallInvoker { get; }
@@ -41,11 +43,11 @@ namespace DivertR
             }
         }
 
-        public DiverterSettings(
-            IProxyFactory? proxyFactory = null,
+        public DiverterSettings(IProxyFactory? proxyFactory = null,
             IDiverterProxyFactory? diverterProxyFactory = null,
             IRedirectProxyDecorator? redirectProxyDecorator = null,
             bool defaultWithDummyRoot = true,
+            bool cacheRedirectProxies = true,
             IDummyFactory? dummyFactory = null,
             ICallInvoker? callInvoker = null)
         {
@@ -53,6 +55,7 @@ namespace DivertR
             DiverterProxyFactory = diverterProxyFactory ?? new DiverterProxyFactory();
             RedirectProxyDecorator = redirectProxyDecorator ?? new RedirectProxyDecorator();
             DefaultWithDummyRoot = defaultWithDummyRoot;
+            CacheRedirectProxies = cacheRedirectProxies;
             DummyFactory = dummyFactory ?? new DummyFactory();
             CallInvoker = callInvoker ?? DefaultCallInvoker;
         }

--- a/test/DivertR.UnitTests/RedirectTests.cs
+++ b/test/DivertR.UnitTests/RedirectTests.cs
@@ -61,6 +61,35 @@ namespace DivertR.UnitTests
             // ASSERT
             testAction.ShouldThrow<ArgumentException>();
         }
+        
+        [Fact]
+        public void GivenDefaultDiverterSettings_WhenCreateProxiesWithSameRootInstance_ShouldCache()
+        {
+            // ARRANGE
+            var foo = new Foo();
+            var proxy = _redirect.Proxy(foo);
+
+            // ACT
+            var testProxy = _redirect.Proxy(foo);
+
+            // ASSERT
+            testProxy.ShouldBeSameAs(proxy);
+        }
+
+        [Fact]
+        public void GivenCacheRedirectProxiesDisabled_WhenCreateProxiesWithSameRootInstance_ShouldNotCache()
+        {
+            // ARRANGE
+            var redirect = new Redirect<IFoo>(new DiverterSettings(cacheRedirectProxies: false));
+            var foo = new Foo();
+            var proxy = redirect.Proxy(foo);
+
+            // ACT
+            var testProxy = redirect.Proxy(foo);
+
+            // ASSERT
+            testProxy.ShouldNotBeSameAs(proxy);
+        }
 
         [Fact]
         public void GivenStrictModeWithNoVia_ShouldThrowException()


### PR DESCRIPTION
Maintain a `ConditionalWeakTable` cache of `Redirect` proxy instances keyed against proxy root instances. If an existing proxy has been created from a `Redirect` with a root instance and another proxy is created with the same root instance then the same cached proxy instance is returned.

As well as being an optimisation the intention is that a system that has its instances replaced with proxies will behave more closely to the original e.g. in terms of instance equality.