### PR TITLE
Copy over existing IRedirect builder methods to IDiverterRedirectBuilder

### DIFF
--- a/src/DivertR/CallArguments.cs
+++ b/src/DivertR/CallArguments.cs
@@ -7,7 +7,7 @@ namespace DivertR
     public class CallArguments : IReadOnlyList<object>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public CallArguments(object[] args)
+        public CallArguments(params object[] args)
         {
             InternalArgs = args;
         }

--- a/src/DivertR/DiverterBuilder.cs
+++ b/src/DivertR/DiverterBuilder.cs
@@ -161,7 +161,7 @@ namespace DivertR
         }
 
         /// <inheritdoc />
-        public IDiverterBuilder AddRedirect<TTarget>(string? name = null) where TTarget : class?
+        public IDiverterBuilder IncludeRedirect<TTarget>(string? name = null) where TTarget : class?
         {
             _diverter.RedirectSet.GetOrCreate<TTarget>(name);
 
@@ -169,7 +169,7 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IDiverterBuilder AddRedirect(Type type, string? name = null)
+        public IDiverterBuilder IncludeRedirect(Type type, string? name = null)
         {
             _diverter.RedirectSet.GetOrCreate(type, name);
 
@@ -177,7 +177,7 @@ namespace DivertR
         }
         
         /// <inheritdoc />
-        public IDiverterRedirectBuilder<TTarget> ExtendRedirect<TTarget>(string? name = null) where TTarget : class?
+        public IDiverterRedirectBuilder<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?
         {
             var redirect = _diverter.Redirect<TTarget>();
             
@@ -203,12 +203,14 @@ namespace DivertR
             return new RedirectDecoratorCallHandler<TReturn>(_diverter, decorator);
         }
         
-        internal static Action<IViaOptionsBuilder> GetOptions()
+        internal static Action<IViaOptionsBuilder> GetOptions(Action<IViaOptionsBuilder>? optionsAction)
         {
-            return opt =>
+            return options =>
             {
-                opt.DisableSatisfyStrict();
-                opt.Persist();
+                options.DisableSatisfyStrict();
+                options.Persist();
+                
+                optionsAction?.Invoke(options);
             };
         }
         

--- a/src/DivertR/IDiverterBuilder.cs
+++ b/src/DivertR/IDiverterBuilder.cs
@@ -163,7 +163,7 @@ namespace DivertR
         /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/>.</param>
         /// <typeparam name="TTarget">The <see cref="IRedirect{TTarget}"/> target type.</typeparam>
         /// <returns>This <see cref="IDiverterBuilder"/> instance.</returns>
-        IDiverterBuilder AddRedirect<TTarget>(string? name = null) where TTarget : class?;
+        IDiverterBuilder IncludeRedirect<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
         /// Add a standalone <see cref="IRedirect{TTarget}"/> without registering a dependency injection service decorator.
@@ -171,7 +171,7 @@ namespace DivertR
         /// <param name="type">The <see cref="IRedirect{TTarget}"/> target type.</param>
         /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/>.</param>
         /// <returns>This <see cref="IDiverterBuilder"/> instance.</returns>
-        IDiverterBuilder AddRedirect(Type type, string? name = null);
+        IDiverterBuilder IncludeRedirect(Type type, string? name = null);
         
         /// <summary>
         /// Create and return a child builder for extending and configuring an existing <see cref="IRedirect{TTarget}"/> instance.
@@ -180,7 +180,7 @@ namespace DivertR
         /// <typeparam name="TTarget">The <see cref="IRedirect{TTarget}"/> target type.</typeparam>
         /// <returns>The created child builder.</returns>
         /// <exception cref="DiverterException">Thrown if an existing <see cref="IRedirect{TTarget}"/> has not been registered.</exception>
-        IDiverterRedirectBuilder<TTarget> ExtendRedirect<TTarget>(string? name = null) where TTarget : class?;
+        IDiverterRedirectBuilder<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?;
         
         /// <summary>
         /// Create an <see cref="IDiverter"/> instance from the current registrations.

--- a/src/DivertR/IDiverterRedirectBuilder.cs
+++ b/src/DivertR/IDiverterRedirectBuilder.cs
@@ -4,37 +4,77 @@ using System.Linq.Expressions;
 namespace DivertR
 {
     /// <summary>
-    /// A Diverter Redirect builder interface for configuring redirect behaviour.
+    /// A Diverter Redirect builder interface for configuring <see cref="IRedirect{TTarget}"/> behaviour.
+    /// By default all <see cref="IVia"/> instances added by this builder are configured to be persistent and to not satisfy strict checks.
     /// </summary>
     /// <typeparam name="TTarget">The <see cref="IRedirect{TTarget}"/> target type.</typeparam>
     public interface IDiverterRedirectBuilder<TTarget> where TTarget : class?
     {
         /// <summary>
-        /// Register a redirect to proxy all calls with return type <typeparamref name="TReturn"/> via an <see cref="IRedirect{TReturn}"/>.
-        /// The returned instances are proxied by inserting a persistent <see cref="IVia"/> on the parent <see cref="IRedirect{TTarget}"/>.
+        /// The underlying Redirect configured by the builder
         /// </summary>
+        IRedirect<TTarget> Redirect { get; }
+        
+        /// <summary>
+        /// Insert a <see cref="IVia"/> into the Redirect.
+        /// </summary>
+        /// <param name="via">The Via instance to insert.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Via(IVia via, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Add a <see cref="IRedirect{TReturn}"/> and proxy all calls with return type <typeparamref name="TReturn"/> via the added redirect.
+        /// The added <see cref="IRedirect{TReturn}"/> has default <see cref="RedirectId.Name" />.
+        /// </summary>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
         /// <typeparam name="TReturn">The return type of calls to redirect.</typeparam>
         /// <returns>The parent builder.</returns>
-        /// <exception cref="DiverterException">Thrown if a nested <see cref="IRedirect{TReturn}"/> has already been registered on the parent with matching <typeparamref name="TReturn"/> type and default <see cref="RedirectId.Name" />.</exception>
-        IDiverterBuilder ViaRedirect<TReturn>(string? name = null) where TReturn : class?;
-        
+        /// <exception cref="DiverterException">Thrown if a nested <see cref="IRedirect{TReturn}"/> has already been registered on the parent with matching <typeparamref name="TReturn"/> type and <see cref="RedirectId.Name" />.</exception>
+        IDiverterBuilder ViaRedirect<TReturn>(Action<IViaOptionsBuilder>? optionsAction = null) where TReturn : class?;
+
         /// <summary>
-        /// Register a decorator that will be applied to all call returns of type <typeparamref name="TReturn"/>.
-        /// The returned instances are proxied to the decorator by inserting a persistent <see cref="IVia"/> on the parent <see cref="IRedirect{TTarget}"/>.
+        /// Add a <see cref="IRedirect{TReturn}"/> and proxy all calls with return type <typeparamref name="TReturn"/> via the added redirect.
+        /// </summary>
+        /// <param name="name">The <see cref="RedirectId.Name" /> of the added <see cref="IRedirect"/>.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <typeparam name="TReturn">The return type of calls to redirect.</typeparam>
+        /// <returns>The parent builder.</returns>
+        /// <exception cref="DiverterException">Thrown if a nested <see cref="IRedirect{TReturn}"/> has already been registered on the parent with matching <typeparamref name="TReturn"/> type and <see cref="RedirectId.Name" />.</exception>
+        IDiverterBuilder ViaRedirect<TReturn>(string? name, Action<IViaOptionsBuilder>? optionsAction = null) where TReturn : class?;
+
+        /// <summary>
+        /// Add a decorator that will be applied to all call returns of type <typeparamref name="TReturn"/>.
         /// </summary>
         /// <param name="decorator">The decorator function.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
         /// <typeparam name="TReturn">The return type of calls to decorate.</typeparam>
         /// <returns>The parent builder.</returns>
-        IDiverterBuilder Decorate<TReturn>(Func<TReturn, TReturn> decorator);
-        
+        IDiverterBuilder Decorate<TReturn>(Func<TReturn, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null);
+
         /// <summary>
-        /// Register a decorator that will be applied to all call returns of type <typeparamref name="TReturn"/>.
-        /// The returned instances are proxied to the decorator by inserting a persistent <see cref="IVia"/> on the parent <see cref="IRedirect{TTarget}"/>.
+        /// Add a decorator that will be applied to all call returns of type <typeparamref name="TReturn"/>.
         /// </summary>
         /// <param name="decorator">The decorator function.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
         /// <typeparam name="TReturn">The return type of calls to decorate.</typeparam>
         /// <returns>The parent builder.</returns>
-        IDiverterBuilder Decorate<TReturn>(Func<TReturn, IDiverter, TReturn> decorator);
+        IDiverterBuilder Decorate<TReturn>(Func<TReturn, IDiverter, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Retarget all <see cref="IRedirect{TTarget}"/> calls to the given <paramref name="target"/> instance.
+        /// </summary>
+        /// <param name="target">The target instance to retarget calls to.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Creates and returns a Diverter Redirect builder with a filter on calls matching the given constraint expression.
+        /// </summary>
+        /// <param name="callConstraint">Optional call constraint <see cref="ICallConstraint"/>.</param>
+        /// <returns>The updater instance.</returns>
+        IDiverterRedirectToBuilder<TTarget> To(ICallConstraint? callConstraint = null);
         
         /// <summary>
         /// Creates and returns a Diverter Redirect builder with a filter on calls matching the given constraint expression for class types.
@@ -53,5 +93,21 @@ namespace DivertR
         /// <typeparam name="TReturn">The constraint expression return type.</typeparam>
         /// <returns>The created child builder.</returns>
         IDiverterRedirectToBuilder<TTarget, TReturn> To<TReturn>(Expression<Func<TTarget, TReturn>> constraintExpression, TReturn? _ = null) where TReturn : struct;
+        
+        /// <summary>
+        /// Creates and returns a Diverter Redirect builder with a filter on void returning calls matching the given constraint expression.
+        /// </summary>
+        /// <param name="constraintExpression">The call constraint expression.</param>
+        /// <returns>The created child builder.</returns>
+        IDiverterRedirectToVoidBuilder<TTarget> To(Expression<Action<TTarget>> constraintExpression);
+        
+        /// <summary>
+        /// Creates and returns a Diverter Redirect builder with a filter on void returning property setter calls matching the given constraint expression.
+        /// </summary>
+        /// <param name="memberExpression">The expression for matching the property setter member.</param>
+        /// <param name="constraintExpression">Optional constraint expression on the setter input argument. If null, the constraint defaults to match any value</param>
+        /// <typeparam name="TProperty">The member type of the property setter.</typeparam>
+        /// <returns>The created child builder.</returns>
+        IDiverterRedirectToVoidBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty>>? constraintExpression = null);
     }
 }

--- a/src/DivertR/IDiverterRedirectToVoidBuilder.cs
+++ b/src/DivertR/IDiverterRedirectToVoidBuilder.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+
+namespace DivertR
+{
+    /// <summary>
+    /// A Diverter Redirect builder interface for configuring <see cref="IRedirect{TTarget}"/> behaviour on methods with void return type.
+    /// By default all <see cref="IVia"/> instances added by this builder are configured to be persistent and to not satisfy strict checks.
+    /// </summary>
+    /// <typeparam name="TTarget">The <see cref="IRedirect{TTarget}"/> target type.</typeparam>
+    public interface IDiverterRedirectToVoidBuilder<TTarget> where TTarget : class?
+    {
+        /// <summary>
+        /// Append an additional filter to the existing constraint.
+        /// </summary>
+        /// <param name="callConstraint">The call constraint filter.</param>
+        /// <returns>This instance.</returns>
+        IDiverterRedirectToVoidBuilder<TTarget> Filter(ICallConstraint callConstraint);
+        
+        /// <summary>
+        /// Redirect calls via the given <paramref name="callHandler"/>.
+        /// </summary>
+        /// <param name="callHandler">The call handler.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Via(ICallHandler callHandler, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Redirect calls via the given delegate handler.
+        /// </summary>
+        /// <param name="viaDelegate">The handler delegate.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Via(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Redirect calls via the given call delegate handler.
+        /// </summary>
+        /// <param name="viaDelegate">The call handler delegate.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Via(Action<IActionRedirectCall<TTarget>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null);
+        
+        /// <summary>
+        /// Redirect calls with ValueTuple arguments via the given delegate handler.
+        /// </summary>
+        /// <param name="viaDelegate">The call handler delegate.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <typeparam name="TArgs">The ValueTuple type to map call arguments to.</typeparam>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
+            where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable;
+        
+        /// <summary>
+        /// Retarget calls to a given <paramref name="target"/> instance.
+        /// </summary>
+        /// <param name="target">The target to retarget calls too.</param>
+        /// <param name="optionsAction">Optional <see cref="IViaOptionsBuilder"/> action.</param>
+        /// <returns>The parent builder.</returns>
+        IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null);
+    }
+}

--- a/src/DivertR/Internal/DiverterRedirectBuilder.cs
+++ b/src/DivertR/Internal/DiverterRedirectBuilder.cs
@@ -5,60 +5,101 @@ namespace DivertR.Internal
 {
     internal class DiverterRedirectBuilder<TTarget> : IDiverterRedirectBuilder<TTarget> where TTarget : class?
     {
-        private readonly IRedirect<TTarget> _redirect;
         private readonly DiverterBuilder _diverterBuilder;
 
         public DiverterRedirectBuilder(IRedirect<TTarget> redirect, DiverterBuilder diverterBuilder)
         {
-            _redirect = redirect;
+            Redirect = redirect;
             _diverterBuilder = diverterBuilder;
         }
+        
+        public IRedirect<TTarget> Redirect { get; }
 
-        public IDiverterBuilder ViaRedirect<TReturn>(string? name = null) where TReturn : class?
+        public IDiverterBuilder Via(IVia via, Action<IViaOptionsBuilder>? optionsAction = null)
         {
-            var nestedRedirect = _redirect.RedirectSet.GetOrCreate<TReturn>(name);
+            Redirect.Via(via, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder ViaRedirect<TReturn>(Action<IViaOptionsBuilder>? optionsAction = null) where TReturn : class?
+        {
+            return ViaRedirect<TReturn>(null, optionsAction);
+        }
+
+        public IDiverterBuilder ViaRedirect<TReturn>(string? name, Action<IViaOptionsBuilder>? optionsAction = null) where TReturn : class?
+        {
+            var nestedRedirect = Redirect.RedirectSet.GetOrCreate<TReturn>(name);
             
-            if (!_diverterBuilder.TryAddNestedRedirect(_redirect.RedirectId, nestedRedirect.RedirectId))
+            if (!_diverterBuilder.TryAddNestedRedirect(Redirect.RedirectId, nestedRedirect.RedirectId))
             {
                 throw new DiverterException($"Nested redirect already registered {nestedRedirect.RedirectId}");
             }
 
-            _redirect.ViaRedirect<TReturn>(name, DiverterBuilder.GetOptions());
+            Redirect.ViaRedirect<TReturn>(name, DiverterBuilder.GetOptions(optionsAction));
             
             return _diverterBuilder;
         }
 
-        public IDiverterBuilder Decorate<TReturn>(Func<TReturn, TReturn> decorator)
+        public IDiverterBuilder Decorate<TReturn>(Func<TReturn, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null)
         {
-            _redirect.Decorate(decorator, DiverterBuilder.GetOptions());
+            Redirect.Decorate(decorator, DiverterBuilder.GetOptions(optionsAction));
 
             return _diverterBuilder;
         }
 
-        public IDiverterBuilder Decorate<TReturn>(Func<TReturn, IDiverter, TReturn> decorator)
+        public IDiverterBuilder Decorate<TReturn>(Func<TReturn, IDiverter, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             var callConstraint = new ReturnCallConstraint(typeof(TReturn));
             var callHandler = _diverterBuilder.CreateDecoratorHandler(decorator);
 
-            _redirect
+            Redirect
                 .To(callConstraint)
-                .Via(callHandler, DiverterBuilder.GetOptions());
+                .Via(callHandler, DiverterBuilder.GetOptions(optionsAction));
 
             return _diverterBuilder;
         }
 
+        public IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            Redirect.Retarget(target, DiverterBuilder.GetOptions(optionsAction));
+            
+            return _diverterBuilder;
+        }
+
+        public IDiverterRedirectToBuilder<TTarget> To(ICallConstraint? callConstraint = null)
+        {
+            var redirectUpdater = Redirect.To(callConstraint);
+            
+            return new DiverterRedirectToBuilder<TTarget>(_diverterBuilder, redirectUpdater);
+        }
+
         public IDiverterRedirectToBuilder<TTarget, TReturn> To<TReturn>(Expression<Func<TTarget, TReturn>> constraintExpression, TReturn? _ = null) where TReturn : class?
         {
-            var redirectUpdater = _redirect.To(constraintExpression);
+            var redirectUpdater = Redirect.To(constraintExpression);
             
             return new DiverterRedirectToClassBuilder<TTarget, TReturn>(_diverterBuilder, redirectUpdater);
         }
 
         public IDiverterRedirectToBuilder<TTarget, TReturn> To<TReturn>(Expression<Func<TTarget, TReturn>> constraintExpression, TReturn? _ = null) where TReturn : struct
         {
-            var redirectUpdater = _redirect.To(constraintExpression);
+            var redirectUpdater = Redirect.To(constraintExpression);
             
             return new DiverterRedirectToBuilder<TTarget, TReturn>(_diverterBuilder, redirectUpdater);
+        }
+
+        public IDiverterRedirectToVoidBuilder<TTarget> To(Expression<Action<TTarget>> constraintExpression)
+        {
+            var redirectUpdater = Redirect.To(constraintExpression);
+            
+            return new DiverterRedirectToVoidBuilder<TTarget>(_diverterBuilder, redirectUpdater);
+        }
+
+        public IDiverterRedirectToVoidBuilder<TTarget> ToSet<TProperty>(Expression<Func<TTarget, TProperty>> memberExpression, Expression<Func<TProperty>>? constraintExpression = null)
+        {
+            var redirectUpdater = Redirect.ToSet(memberExpression, constraintExpression);
+            
+            return new DiverterRedirectToVoidBuilder<TTarget>(_diverterBuilder, redirectUpdater);
         }
     }
 }

--- a/src/DivertR/Internal/DiverterRedirectToBuilder.cs
+++ b/src/DivertR/Internal/DiverterRedirectToBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 
 namespace DivertR.Internal
 {
@@ -20,23 +21,69 @@ namespace DivertR.Internal
             return this;
         }
 
-        public virtual IDiverterBuilder ViaRedirect(string? name = null)
+        public IDiverterBuilder Via(ICallHandler callHandler, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            RedirectUpdater.Via(callHandler, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+
+        public IDiverterBuilder Via(TReturn instance, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            RedirectUpdater.Via(instance, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+
+        public IDiverterBuilder Via(Func<TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            RedirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+
+        public IDiverterBuilder Via(Func<IFuncRedirectCall<TTarget, TReturn>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            RedirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+        
+        public IDiverterBuilder Via<TArgs>(Func<IFuncRedirectCall<TTarget, TReturn, TArgs>, TReturn> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        {
+            RedirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+
+        public IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            RedirectUpdater.Retarget(target, DiverterBuilder.GetOptions(optionsAction));
+            
+            return DiverterBuilder;
+        }
+
+        public IDiverterBuilder ViaRedirect(Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            return ViaRedirect(null, optionsAction);
+        }
+
+        public virtual IDiverterBuilder ViaRedirect(string? name, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             throw new InvalidOperationException($"Invalid return type for Redirect. {typeof(TReturn)} is a struct type but only class types are valid.");
         }
 
-        public IDiverterBuilder Decorate(Func<TReturn, TReturn> decorator)
+        public IDiverterBuilder Decorate(Func<TReturn, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null)
         {
-            RedirectUpdater
-                .Decorate(decorator, DiverterBuilder.GetOptions());
+            RedirectUpdater.Decorate(decorator, DiverterBuilder.GetOptions(optionsAction));
 
             return DiverterBuilder;
         }
 
-        public IDiverterBuilder Decorate(Func<TReturn, IDiverter, TReturn> decorator)
+        public IDiverterBuilder Decorate(Func<TReturn, IDiverter, TReturn> decorator, Action<IViaOptionsBuilder>? optionsAction = null)
         {
             var callHandler = DiverterBuilder.CreateDecoratorHandler(decorator);
-            RedirectUpdater.Via(callHandler, DiverterBuilder.GetOptions());
+            RedirectUpdater.Via(callHandler, DiverterBuilder.GetOptions(optionsAction));
 
             return DiverterBuilder;
         }
@@ -51,11 +98,44 @@ namespace DivertR.Internal
         {
         }
 
-        public override IDiverterBuilder ViaRedirect(string? name = null)
+        public override IDiverterBuilder ViaRedirect(string? name, Action<IViaOptionsBuilder>? optionsAction = null)
         {
-            RedirectUpdater.ViaRedirect(name, DiverterBuilder.GetOptions());
+            RedirectUpdater.ViaRedirect(name, DiverterBuilder.GetOptions(optionsAction));
 
             return DiverterBuilder;
+        }
+    }
+
+    internal class DiverterRedirectToBuilder<TTarget> : IDiverterRedirectToBuilder<TTarget> where TTarget : class?
+    {
+        private readonly DiverterBuilder _diverterBuilder;
+        private readonly IRedirectUpdater<TTarget> _redirectUpdater;
+
+        public DiverterRedirectToBuilder(DiverterBuilder diverterBuilder, IRedirectUpdater<TTarget> redirectUpdater)
+        {
+            _diverterBuilder = diverterBuilder;
+            _redirectUpdater = redirectUpdater;
+        }
+        
+        public IDiverterRedirectToBuilder<TTarget> Filter(ICallConstraint callConstraint)
+        {
+            _redirectUpdater.Filter(callConstraint);
+
+            return this;
+        }
+
+        public IDiverterBuilder Via(ICallHandler callHandler, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Via(callHandler, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Retarget(target, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
         }
     }
 }

--- a/src/DivertR/Internal/DiverterRedirectToVoidBuilder.cs
+++ b/src/DivertR/Internal/DiverterRedirectToVoidBuilder.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections;
+
+namespace DivertR.Internal
+{
+    internal class DiverterRedirectToVoidBuilder<TTarget> : IDiverterRedirectToVoidBuilder<TTarget> where TTarget : class?
+    {
+        private readonly DiverterBuilder _diverterBuilder;
+        private readonly IActionRedirectUpdater<TTarget> _redirectUpdater;
+
+        public DiverterRedirectToVoidBuilder(DiverterBuilder diverterBuilder, IActionRedirectUpdater<TTarget> redirectUpdater)
+        {
+            _diverterBuilder = diverterBuilder;
+            _redirectUpdater = redirectUpdater;
+        }
+
+        public IDiverterRedirectToVoidBuilder<TTarget> Filter(ICallConstraint callConstraint)
+        {
+            _redirectUpdater.Filter(callConstraint);
+
+            return this;
+        }
+
+        public IDiverterBuilder Via(ICallHandler callHandler, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Via(callHandler, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder Via(Action viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder Via(Action<IActionRedirectCall<TTarget>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder Via<TArgs>(Action<IActionRedirectCall<TTarget, TArgs>> viaDelegate, Action<IViaOptionsBuilder>? optionsAction = null) where TArgs : struct, IStructuralComparable, IStructuralEquatable, IComparable
+        {
+            _redirectUpdater.Via(viaDelegate, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+
+        public IDiverterBuilder Retarget(TTarget target, Action<IViaOptionsBuilder>? optionsAction = null)
+        {
+            _redirectUpdater.Retarget(target, DiverterBuilder.GetOptions(optionsAction));
+
+            return _diverterBuilder;
+        }
+    }
+}

--- a/test/DivertR.UnitTests/DiverterBuilderTests.cs
+++ b/test/DivertR.UnitTests/DiverterBuilderTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace DivertR.UnitTests
 {
-    public class DiverterTests
+    public class DiverterBuilderTests
     {
         private readonly IDiverterBuilder _diverterBuilder = new DiverterBuilder();
 
@@ -283,7 +283,7 @@ namespace DivertR.UnitTests
         public void AddRedirect_ShouldAdd()
         {
             // ARRANGE
-            var diverter = _diverterBuilder.AddRedirect<IFoo>().Create();
+            var diverter = _diverterBuilder.IncludeRedirect<IFoo>().Create();
 
             // ACT
             var foo = diverter.Redirect<IFoo>().Proxy();
@@ -296,7 +296,7 @@ namespace DivertR.UnitTests
         public void AddNamedRedirect_ShouldAdd()
         {
             // ARRANGE
-            var diverter = _diverterBuilder.AddRedirect<IFoo>("test").Create();
+            var diverter = _diverterBuilder.IncludeRedirect<IFoo>("test").Create();
 
             // ACT
             var foo = diverter.Redirect<IFoo>("test").Proxy();
@@ -309,7 +309,7 @@ namespace DivertR.UnitTests
         public void AddRedirectByType_ShouldAdd()
         {
             // ARRANGE
-            var diverter = _diverterBuilder.AddRedirect(typeof(IFoo)).Create();
+            var diverter = _diverterBuilder.IncludeRedirect(typeof(IFoo)).Create();
 
             // ACT
             var foo = diverter.Redirect<IFoo>().Proxy();
@@ -322,7 +322,7 @@ namespace DivertR.UnitTests
         public void AddNamedRedirectByType_ShouldAdd()
         {
             // ARRANGE
-            var diverter = _diverterBuilder.AddRedirect(typeof(IFoo), "test").Create();
+            var diverter = _diverterBuilder.IncludeRedirect(typeof(IFoo), "test").Create();
 
             // ACT
             var foo = diverter.Redirect<IFoo>("test").Proxy();
@@ -337,7 +337,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
 
             diverter
@@ -359,7 +359,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
 
@@ -381,7 +381,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>("group")
+                .Redirect<IFoo>().ViaRedirect<IBar>("group")
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
 
@@ -403,7 +403,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
 
@@ -425,7 +425,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
 
@@ -447,8 +447,8 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IFoo>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
             
             var foo = new Foo("inner");
@@ -473,7 +473,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IFoo>()
+                .Redirect<IFoo>().ViaRedirect<IFoo>()
                 .Create();
 
             var foo = new Foo("inner");
@@ -492,7 +492,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -520,9 +520,9 @@ namespace DivertR.UnitTests
             {
                 _diverterBuilder
                     .Register<IFoo>()
-                    .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
-                    .ExtendRedirect<IFoo>().ViaRedirect<IFoo>()
-                    .ExtendRedirect<IFoo>().ViaRedirect<IBar>();
+                    .Redirect<IFoo>().ViaRedirect<IBar>()
+                    .Redirect<IFoo>().ViaRedirect<IFoo>()
+                    .Redirect<IFoo>().ViaRedirect<IBar>();
             };
 
             // ASSERT
@@ -535,7 +535,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().ViaRedirect<IBar>()
+                .Redirect<IFoo>().ViaRedirect<IBar>()
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -554,7 +554,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().To(x => x.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
+                .Redirect<IFoo>().To(x => x.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
                 .Create();
             
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -577,7 +577,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().To(x => x.EchoGeneric(Is<IBar>.Any)).ViaRedirect("group")
+                .Redirect<IFoo>().To(x => x.EchoGeneric(Is<IBar>.Any)).ViaRedirect("group")
                 .Create();
             
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -600,7 +600,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().To(foo => foo.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
+                .Redirect<IFoo>().To(foo => foo.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -624,7 +624,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().To(foo => foo.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
+                .Redirect<IFoo>().To(foo => foo.EchoGeneric(Is<IBar>.Any)).ViaRedirect()
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -643,7 +643,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
+                .Redirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
             
@@ -660,8 +660,8 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .AddRedirect<IBar>()
-                .ExtendRedirect<IFoo>().Decorate<IBar>((bar, d) => d.Redirect<IBar>().Proxy(new Bar(bar.Name + " decorated")))
+                .IncludeRedirect<IBar>()
+                .Redirect<IFoo>().Decorate<IBar>((bar, d) => d.Redirect<IBar>().Proxy(new Bar(bar.Name + " decorated")))
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
             
@@ -679,7 +679,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>()
+                .Redirect<IFoo>()
                     .To(x => x.EchoGeneric(Is<IBar>.Any))
                     .Decorate(bar => new Bar(bar.Name + " decorated"))
                 .Create();
@@ -699,8 +699,8 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .AddRedirect<IBar>()
-                .ExtendRedirect<IFoo>()
+                .IncludeRedirect<IBar>()
+                .Redirect<IFoo>()
                     .To(x => x.EchoGeneric(Is<IBar>.Any))
                     .Decorate((bar, d) => d.Redirect<IBar>().Proxy(new Bar(bar.Name + " decorated")))
                 .Create();
@@ -719,7 +719,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().Decorate<int>(n => n + 1)
+                .Redirect<IFoo>().Decorate<int>(n => n + 1)
                 .Create();
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
             
@@ -736,7 +736,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
+                .Redirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
                 .Create();
 
             var bar = new Bar("bar");
@@ -756,7 +756,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
+                .Redirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());
@@ -775,7 +775,7 @@ namespace DivertR.UnitTests
             // ARRANGE
             var diverter = _diverterBuilder
                 .Register<IFoo>()
-                .ExtendRedirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
+                .Redirect<IFoo>().Decorate<IBar>(bar => new Bar(bar.Name + " decorated"))
                 .Create();
 
             var fooProxy = diverter.Redirect<IFoo>().Proxy(new Foo());

--- a/test/DivertR.UnitTests/DiverterRedirectBuilderTests.cs
+++ b/test/DivertR.UnitTests/DiverterRedirectBuilderTests.cs
@@ -1,0 +1,425 @@
+﻿using DivertR.DependencyInjection;
+using DivertR.UnitTests.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace DivertR.UnitTests;
+
+public class DiverterRedirectBuilderTests
+{
+    private readonly IDiverterRedirectBuilder<IFoo> _builder;
+    private readonly IDiverter _diverter;
+    private readonly IFoo _fooProxy;
+    
+    public DiverterRedirectBuilderTests()
+    {
+        var diverterBuilder = new DiverterBuilder().Register<IFoo>();
+        _builder = diverterBuilder.Redirect<IFoo>();
+        _diverter = diverterBuilder.Create();
+
+        var serviceProvider = new ServiceCollection()
+            .AddTransient<IFoo, Foo>()
+            .Divert(_diverter)
+            .BuildServiceProvider();
+
+        _fooProxy = serviceProvider.GetRequiredService<IFoo>();
+    }
+    
+    [Fact]
+    public void GivenToViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.Name).Via(call => call.CallNext() + " redirected");
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("original redirected");
+    }
+    
+    [Fact]
+    public void GivenToViaRegisteredWithOptions_ShouldApplyOptions()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.Name)
+            .Via(call => call.CallNext() + " redirected", opt => opt.Persist(false));
+        
+        _diverter.ResetAll(); // builder changes should not be persistant now
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("original");
+    }
+    
+    [Fact]
+    public void GivenToViaArgsRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.Echo(Is<string>.Any))
+            .Via<(string echo, __)>(call => call.CallNext() + $" redirected {call.Args.echo}");
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Echo("test");
+            
+        // ASSERT
+        result.ShouldBe("original: test redirected test");
+    }
+    
+    [Fact]
+    public void GivenToViaInstanceRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.Name).Via("redirected");
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("redirected");
+    }
+    
+    [Fact]
+    public void GivenToViaDelegateRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.Name).Via(() => "redirected");
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("redirected");
+    }
+    
+    [Fact]
+    public void GivenToViaCallHandlerRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.Name)
+            .Via(new DelegateCallHandler(call => call.CallNext() + " redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("original redirected");
+    }
+    
+    [Fact]
+    public void GivenToViaRetargetRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        var altFoo = new Foo("alt");
+        
+        _builder
+            .To(x => x.Echo("test"))
+            .Retarget(altFoo);
+            
+        _diverter.ResetAll(); // builder changes should be persistant
+        
+        // ACT
+        var result1 = _fooProxy.Echo("test");
+        var result2 = _fooProxy.Echo("test2");
+        
+        // ASSERT
+        result1.ShouldBe("alt: test");
+        result2.ShouldBe("original: test2");
+    }
+    
+    [Fact]
+    public void GivenToViaWithFilterRegistered_ShouldFilter()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.Echo(Is<string>.Any))
+            .Filter(new DelegateCallConstraint(call => (string) call.Arguments[0] == "test"))
+            .Via(call => call.CallNext() + " redirected");
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result1 = _fooProxy.Echo("test");
+        var result2 = _fooProxy.Echo("test2");
+            
+        // ASSERT
+        result1.ShouldBe("original: test redirected");
+        result2.ShouldBe("original: test2");
+    }
+    
+    [Fact]
+    public void GivenToVoidViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.SetName(Is<string>.Any))
+            .Via(call => call.Next.SetName($"{call.Args[0]} redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.SetName("test");
+            
+        // ASSERT
+        _fooProxy.Name.ShouldBe("test redirected");
+    }
+    
+    [Fact]
+    public void GivenToVoidViaWithFilterRegistered_ShouldFilter()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.SetName(Is<string>.Any))
+            .Filter(new DelegateCallConstraint(call => (string) call.Arguments[0] == "test"))
+            .Via(call => call.Next.SetName($"{call.Args[0]} redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.SetName("test");
+        var testName = _fooProxy.Name;
+        _fooProxy.SetName("test2");
+        var filteredName = _fooProxy.Name;
+            
+        // ASSERT
+        testName.ShouldBe("test redirected");
+        filteredName.ShouldBe("test2");
+    }
+    
+    [Fact]
+    public void GivenToVoidViaArgsRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.SetName(Is<string>.Any))
+            .Via<(string name, __)>(call => call.Next.SetName($"{call.Args.name} redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.SetName("test");
+            
+        // ASSERT
+        _fooProxy.Name.ShouldBe("test redirected");
+    }
+    
+    [Fact]
+    public void GivenToVoidViaActionRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To(x => x.SetName(Is<string>.Any))
+            .Via(() =>
+            {
+                var call = _builder.Redirect.Relay.GetCurrentCall();
+                _builder.Redirect.Relay.Next.SetName($"{call.Args[0]} redirected");
+            });
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.SetName("test");
+            
+        // ASSERT
+        _fooProxy.Name.ShouldBe("test redirected");
+    }
+    
+    [Fact]
+    public void GivenToVoidViaCallHandlerRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.SetName(Is<string>.Any))
+            .Via(new DelegateCallHandler(call => call.CallNext(new[] { $"{call.Args[0]} redirected" })));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.SetName("test");
+            
+        // ASSERT
+        _fooProxy.Name.ShouldBe("test redirected");
+    }
+
+    [Fact]
+    public void GivenToVoidViaRetargetRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        var spyFoo = Spy.On<IFoo>();
+        
+        _builder
+            .To(x => x.SetName(Is<string>.Any))
+            .Retarget(spyFoo);
+            
+        _diverter.ResetAll(); // builder changes should be persistant
+        
+        // ACT
+        _fooProxy.SetName("test");
+        var name = _fooProxy.Name;
+        
+        // ASSERT
+        name.ShouldBe("original");
+        Spy.Of(spyFoo).Calls.Count.ShouldBe(1);
+        Spy.Of(spyFoo).Calls.To(x => x.SetName("test")).Count.ShouldBe(1);
+    }
+    
+    [Fact]
+    public void GivenToRetarget_ShouldRetarget()
+    {
+        // ARRANGE
+        var altFoo = new Foo("alt");
+        _builder.To().Retarget(altFoo);
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("alt");
+    }
+    
+    [Fact]
+    public void GivenToVia_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To().Via(new DelegateCallHandler(call => call.CallNext() + " redirected"));
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("original redirected");
+    }
+    
+    [Fact]
+    public void GivenToWithConstraint_ShouldFilterRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To(new DelegateCallConstraint(call => (string) call.Arguments[0] == "test"))
+            .Via(new DelegateCallHandler(call => call.CallNext() + " redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result1 = _fooProxy.Echo("test");
+        var result2 = _fooProxy.Echo("test2");
+            
+        // ASSERT
+        result1.ShouldBe("original: test redirected");
+        result2.ShouldBe("original: test2");
+    }
+    
+    [Fact]
+    public void GivenToWithFilter_ShouldFilterRedirect()
+    {
+        // ARRANGE
+        _builder
+            .To()
+            .Filter(new DelegateCallConstraint(call => (string) call.Arguments[0] == "test"))
+            .Via(new DelegateCallHandler(call => call.CallNext() + " redirected"));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result1 = _fooProxy.Echo("test");
+        var result2 = _fooProxy.Echo("test2");
+            
+        // ASSERT
+        result1.ShouldBe("original: test redirected");
+        result2.ShouldBe("original: test2");
+    }
+    
+    [Fact]
+    public void GivenRetarget_ShouldRetarget()
+    {
+        // ARRANGE
+        var altFoo = new Foo("alt");
+        _builder.Retarget(altFoo);
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("alt");
+    }
+    
+    [Fact]
+    public void GivenViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.Via(new Via(new DelegateCallHandler(call => call.CallNext() + " redirected")));
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.Name;
+            
+        // ASSERT
+        result.ShouldBe("original redirected");
+    }
+    
+    [Fact]
+    public void GivenToSetViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .ToSet(x => x.Name)
+            .Via(call => call.CallNext(new[] { call.Args[0] + " redirected" }));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.Name = "test";
+            
+        // ASSERT
+        _fooProxy.Name.ShouldBe("test redirected");
+    }
+    
+    [Fact]
+    public void GivenToSetWithConstraintViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder
+            .ToSet(x => x.Name, () => "test")
+            .Via(call => call.CallNext(new[] { call.Args[0] + " redirected" }));
+        
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        _fooProxy.Name = "test";
+        var result1 = _fooProxy.Name;
+        _fooProxy.Name = "test2";
+        var result2 = _fooProxy.Name;
+            
+        // ASSERT
+        result1.ShouldBe("test redirected");
+        result2.ShouldBe("test2");
+    }
+    
+    [Fact]
+    public void GivenToStructViaRegistered_ShouldRedirect()
+    {
+        // ARRANGE
+        _builder.To(x => x.EchoGeneric(Is<int>.Any)).Via(call => call.CallNext() + 1);
+        _diverter.ResetAll(); // builder changes should be persistant
+
+        // ACT
+        var result = _fooProxy.EchoGeneric(10);
+            
+        // ASSERT
+        result.ShouldBe(11);
+    }
+}

--- a/test/DivertR.UnitTests/RedirectUpdaterTests.cs
+++ b/test/DivertR.UnitTests/RedirectUpdaterTests.cs
@@ -811,7 +811,7 @@ namespace DivertR.UnitTests
                 .Via<(string input, __)>(call => $"{call.Args.input}-test");
             _redirect
                 .To(x => x.Echo("here"))
-                .Via(call => (string?) call.CallNext(call.CallInfo.Method, new CallArguments(new object[] { "alter" }))!);
+                .Via(call => (string?) call.CallNext(call.CallInfo.Method, new CallArguments("alter"))!);
 
             // ACT
             var result = proxy.Echo("here");

--- a/test/DivertR.UnitTests/ServiceCollectionTests.cs
+++ b/test/DivertR.UnitTests/ServiceCollectionTests.cs
@@ -99,7 +99,7 @@ namespace DivertR.UnitTests
             _services.AddSingleton<IFoo, Foo>();
 
             var diverter = new DiverterBuilder()
-                .AddRedirect<IBar>()
+                .IncludeRedirect<IBar>()
                 .Decorate<IFoo>((foo, diverter) =>
                 {
                     var bar = diverter.Redirect<IBar>().Proxy(new Bar("test"));
@@ -121,7 +121,7 @@ namespace DivertR.UnitTests
             _services.AddSingleton<IBar>(_ => new Bar("test"));
 
             var diverter = new DiverterBuilder()
-                .AddRedirect<IBar>()
+                .IncludeRedirect<IBar>()
                 .Decorate<IFoo>((foo, diverter, provider) =>
                 {
                     var bar = diverter.Redirect<IBar>().Proxy(provider.GetRequiredService<IBar>());
@@ -154,7 +154,7 @@ namespace DivertR.UnitTests
             _services.AddSingleton<IFoo, Foo>();
 
             var diverter = new DiverterBuilder()
-                .AddRedirect<IBar>()
+                .IncludeRedirect<IBar>()
                 .Decorate(typeof(IFoo), (foo, diverter) =>
                 {
                     var bar = diverter.Redirect<IBar>().Proxy(new Bar("test"));
@@ -176,7 +176,7 @@ namespace DivertR.UnitTests
             _services.AddSingleton<IBar>(_ => new Bar("test"));
 
             var diverter = new DiverterBuilder()
-                .AddRedirect<IBar>()
+                .IncludeRedirect<IBar>()
                 .Decorate(typeof(IFoo), (foo, diverter, provider) =>
                 {
                     var bar = diverter.Redirect<IBar>().Proxy(provider.GetRequiredService<IBar>());
@@ -331,7 +331,7 @@ namespace DivertR.UnitTests
             _services.AddTransient<List<IFoo>>(_ => new List<IFoo> { new Foo("1"), new Foo("2") });
             var diverterBuilder = new DiverterBuilder();
             var diverter = diverterBuilder
-                .AddRedirect<IFoo>()
+                .IncludeRedirect<IFoo>()
                 .Decorate<List<IFoo>>((foos, diverter) => foos
                     .Select(x => diverter.Redirect<IFoo>().Proxy(x))
                     .ToList()).Create();

--- a/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
+++ b/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
@@ -19,9 +19,9 @@ namespace DivertR.WebAppTests.TestHarness
             .Register<IFooRepository>()
             .Register<IBarServiceFactory>()
             // Extend redirects to redirect inner services not resolved by DI e.g. by factories
-            .ExtendRedirect<IBarServiceFactory>().ViaRedirect<IBarService>()
+            .Redirect<IBarServiceFactory>().ViaRedirect<IBarService>()
             .Register<IFooService>()
-            .AddRedirect<ITestOutputHelper>() // Add a standalone (non DI service) redirect for proxying the xUnit ITestOutputHelper logger.
+            .IncludeRedirect<ITestOutputHelper>() // Add a standalone (non DI service) redirect for proxying the xUnit ITestOutputHelper logger.
             .Create();
 
         private readonly WebApplicationFactory<Program> _webApplicationFactory;


### PR DESCRIPTION
Copy IRedirect fluent interface configurations methods over to the IDiverterRedirectBuilder interface.

An important difference between `IDiverter` and `DiverterBuilder` configurations is that the latter are 'persistent' meaning they do not get removed on reset.

This offers a convenient way to add permanent configurations that do not get reset between tests.