### PR TITLE
Remove RedirectSet property from the IDiverter interface

### DIFF
--- a/src/DivertR/DiverterBuilder.cs
+++ b/src/DivertR/DiverterBuilder.cs
@@ -12,6 +12,7 @@ namespace DivertR
         private readonly ConcurrentDictionary<string, ConcurrentQueue<IServiceDecorator>> _decorators = new();
         private readonly ConcurrentDictionary<RedirectId, IRedirect> _registeredRedirects = new();
         private readonly ConcurrentDictionary<RedirectId, ConcurrentDictionary<RedirectId, RedirectId>> _registeredNested = new();
+        private readonly IRedirectSet _redirectSet;
         private readonly IDiverter _diverter;
 
         /// <summary>
@@ -29,6 +30,9 @@ namespace DivertR
         /// <param name="redirectSet">The <see cref="IRedirectSet"/> instance.</param>
         public DiverterBuilder(IRedirectSet redirectSet)
         {
+            _redirectSet = redirectSet;
+            _redirectSet = redirectSet;
+
             IEnumerable<IServiceDecorator> GetDecorators(string? name = null)
             {
                 return _decorators.TryGetValue(name ?? string.Empty, out var decorators)
@@ -42,7 +46,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverterBuilder Register<TTarget>(string? name = null) where TTarget : class?
         {
-            var redirect = _diverter.RedirectSet.GetOrCreate<TTarget>(name);
+            var redirect = _redirectSet.GetOrCreate<TTarget>(name);
 
             if (!_registeredRedirects.TryAdd(redirect.RedirectId, redirect))
             {
@@ -55,7 +59,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverterBuilder Register(Type targetType, string? name = null)
         {
-            var redirect = _diverter.RedirectSet.GetOrCreate(targetType, name);
+            var redirect = _redirectSet.GetOrCreate(targetType, name);
             
             if (!_registeredRedirects.TryAdd(redirect.RedirectId, redirect))
             {
@@ -163,7 +167,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverterBuilder IncludeRedirect<TTarget>(string? name = null) where TTarget : class?
         {
-            _diverter.RedirectSet.GetOrCreate<TTarget>(name);
+            _redirectSet.GetOrCreate<TTarget>(name);
 
             return this;
         }
@@ -171,7 +175,7 @@ namespace DivertR
         /// <inheritdoc />
         public IDiverterBuilder IncludeRedirect(Type type, string? name = null)
         {
-            _diverter.RedirectSet.GetOrCreate(type, name);
+            _redirectSet.GetOrCreate(type, name);
 
             return this;
         }

--- a/src/DivertR/IDiverter.cs
+++ b/src/DivertR/IDiverter.cs
@@ -13,11 +13,6 @@ namespace DivertR
     public interface IDiverter
     {
         /// <summary>
-        /// The underlying <see cref="IRedirectSet"/> containing the <see cref="IRedirect"/> collection of this <see cref="IDiverter"/> instance.
-        /// </summary>
-        IRedirectSet RedirectSet { get; }
-        
-        /// <summary>
         /// Get the <see cref="IRedirect{TTarget}"/> by <see cref="RedirectId"/> key generated from <typeparamref name="TTarget"/> and optional <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The <see cref="RedirectId.Name" /> of the <see cref="IRedirect"/>.</param>

--- a/src/DivertR/Internal/Diverter.cs
+++ b/src/DivertR/Internal/Diverter.cs
@@ -6,14 +6,13 @@ namespace DivertR.Internal
     internal class Diverter : IDiverter
     {
         private readonly Func<string?, IEnumerable<IServiceDecorator>> _getDecorators;
+        private readonly IRedirectSet _redirectSet;
         
         public Diverter(IRedirectSet redirectSet, Func<string?, IEnumerable<IServiceDecorator>> getDecorators)
         {
-            RedirectSet = redirectSet;
+            _redirectSet = redirectSet;
             _getDecorators = getDecorators;
         }
-
-        public IRedirectSet RedirectSet { get; }
 
         public IRedirect<TTarget> Redirect<TTarget>(string? name = null) where TTarget : class?
         {
@@ -27,7 +26,7 @@ namespace DivertR.Internal
         
         public IRedirect Redirect(RedirectId redirectId)
         {
-            var redirect = RedirectSet.Get(redirectId);
+            var redirect = _redirectSet.Get(redirectId);
             
             if (redirect == null)
             {
@@ -39,28 +38,28 @@ namespace DivertR.Internal
         
         public IDiverter StrictAll()
         {
-            RedirectSet.StrictAll();
+            _redirectSet.StrictAll();
             
             return this;
         }
         
         public IDiverter Strict(string? name = null)
         {
-            RedirectSet.Strict(name);
+            _redirectSet.Strict(name);
 
             return this;
         }
         
         public IDiverter ResetAll()
         {
-            RedirectSet.ResetAll();
+            _redirectSet.ResetAll();
             
             return this;
         }
         
         public IDiverter Reset(string? name = null)
         {
-            RedirectSet.Reset(name);
+            _redirectSet.Reset(name);
 
             return this;
         }

--- a/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
+++ b/test/DivertR.WebAppTests/TestHarness/WebAppFixture.cs
@@ -14,14 +14,18 @@ namespace DivertR.WebAppTests.TestHarness
 {
     public class WebAppFixture
     {
-        // Build a DivertR instance by registering the DI services we want to be able to redirect
+        // Build a Diverter instance
         private readonly IDiverter _diverter = new DiverterBuilder()
+            // Register DI services we want to be able to redirect:
             .Register<IFooRepository>()
             .Register<IBarServiceFactory>()
-            // Extend redirects to redirect inner services not resolved by DI e.g. by factories
-            .Redirect<IBarServiceFactory>().ViaRedirect<IBarService>()
             .Register<IFooService>()
-            .IncludeRedirect<ITestOutputHelper>() // Add a standalone (non DI service) redirect for proxying the xUnit ITestOutputHelper logger.
+            
+            // Include standalone (non DI service) redirects:
+            .IncludeRedirect<ITestOutputHelper>() // Add xUnit ITestOutputHelper logger
+            
+            // Add persistent redirect configurations:
+            .Redirect<IBarServiceFactory>().ViaRedirect<IBarService>() // Redirect proxy IBarService instances created by IBarServiceFactory
             .Create();
 
         private readonly WebApplicationFactory<Program> _webApplicationFactory;
@@ -50,12 +54,12 @@ namespace DivertR.WebAppTests.TestHarness
 
         public IDiverter InitDiverter(ITestOutputHelper? output = null)
         {
-            // Reset all non-persistent Redirect Vias
+            // Reset all non-persistent Redirect configurations
             _diverter.ResetAll();
 
             if (output != null)
             {
-                // Retarget the ITestOutputHelper proxy mock to the current test output
+                // Retarget ITestOutputHelper proxy calls to the current test output
                 _diverter.Redirect<ITestOutputHelper>().Retarget(output);
             }
 


### PR DESCRIPTION
Removing the `IDiverter.RedirectSet ` property to simplify the interface.

With the addition of `DiverterBuilder.IncludeRedirect`, this property is no longer required.